### PR TITLE
Allow window resizing and adapt view components

### DIFF
--- a/include/lilia/view/board_view.hpp
+++ b/include/lilia/view/board_view.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <SFML/System/Vector2.hpp>
 
 #include "board.hpp"
 
@@ -10,9 +11,10 @@ class BoardView {
  public:
   BoardView();
 
-  void init();
-  void renderBoard(sf::RenderWindow& window);
-  [[nodiscard]] Entity::Position getSquareScreenPos(core::Square sq) const;
+    void init();
+    void resize(const sf::Vector2u& windowSize);
+    void renderBoard(sf::RenderWindow& window);
+    [[nodiscard]] Entity::Position getSquareScreenPos(core::Square sq) const;
 
  private:
   Board m_board;

--- a/include/lilia/view/eval_bar.hpp
+++ b/include/lilia/view/eval_bar.hpp
@@ -7,11 +7,12 @@ class RenderWindow;
 
 namespace lilia::view {
 
-class EvalBar : Entity {
+class EvalBar : public Entity {
  public:
   EvalBar();
 
   virtual void setPosition(const Entity::Position &pos) override;
+  void setScale(float width, float height);
   void render(sf::RenderWindow &window);
   void update(int eval);
 

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -27,7 +27,9 @@ class GameView {
   void update(float dt);
   void updateEval(int eval);
 
-  void render();
+    void render();
+
+    void resize(const sf::Vector2u& windowSize);
 
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
   void setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos);
@@ -66,7 +68,7 @@ class GameView {
 
   void setDefaultCursor();
   void setHandOpenCursor();
-  void setHandClosedCursor();
+    void setHandClosedCursor();
 
  private:
   core::MousePos clampPosToWindowSize(core::MousePos mousePos) const noexcept;

--- a/include/lilia/view/highlight_manager.hpp
+++ b/include/lilia/view/highlight_manager.hpp
@@ -20,8 +20,10 @@ class HighlightManager {
   void clearHighlightHoverSquare(core::Square pos);
 
   void renderAttack(sf::RenderWindow& window);
-  void renderHover(sf::RenderWindow& window);
-  void renderSelect(sf::RenderWindow& window);
+    void renderHover(sf::RenderWindow& window);
+    void renderSelect(sf::RenderWindow& window);
+
+    void resize();
 
  private:
   void renderEntitiesToBoard(std::unordered_map<core::Square, Entity>& map,

--- a/include/lilia/view/piece_manager.hpp
+++ b/include/lilia/view/piece_manager.hpp
@@ -32,8 +32,10 @@ class PieceManager {
   void setPieceToScreenPos(core::Square pos, core::MousePos mousePos);
   void setPieceToScreenPos(core::Square pos, Entity::Position entityPos);
 
-  void renderPieces(sf::RenderWindow& window, const animation::ChessAnimator& chessAnimRef);
-  void renderPiece(core::Square pos, sf::RenderWindow& window);
+    void renderPieces(sf::RenderWindow& window, const animation::ChessAnimator& chessAnimRef);
+    void renderPiece(core::Square pos, sf::RenderWindow& window);
+
+    void resizePieces();
 
  private:
   Entity::Position createPiecePositon(core::Square pos);

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -1,23 +1,29 @@
 #pragma once
 #include "../constants.hpp"
+#include <algorithm>
 
 namespace lilia::view::constant {
 constexpr unsigned int BOARD_SIZE = 8;
-constexpr unsigned int WINDOW_PX_SIZE = 800;
-constexpr unsigned int SQUARE_PX_SIZE = WINDOW_PX_SIZE / BOARD_SIZE;
-constexpr unsigned int ATTACK_DOT_PX_SIZE =
+// Distance between the window border and the board on each side
+inline constexpr unsigned int WINDOW_MARGIN = 100;
+inline unsigned int WINDOW_WIDTH = 1000;
+inline unsigned int WINDOW_HEIGHT = 1000;
+inline unsigned int WINDOW_PX_SIZE = 800;  // Board edge length
+inline unsigned int BOARD_OFFSET_X = WINDOW_MARGIN;
+inline unsigned int BOARD_OFFSET_Y = WINDOW_MARGIN;
+inline unsigned int SQUARE_PX_SIZE = WINDOW_PX_SIZE / BOARD_SIZE;
+inline unsigned int ATTACK_DOT_PX_SIZE =
     static_cast<unsigned int>(static_cast<float>(SQUARE_PX_SIZE) * 0.45f + 0.5f);
-constexpr unsigned int CAPTURE_CIRCLE_PX_SIZE =
+inline unsigned int CAPTURE_CIRCLE_PX_SIZE =
     static_cast<unsigned int>(static_cast<float>(SQUARE_PX_SIZE) * 1.02f + 0.5f);
 
-constexpr unsigned int EVAL_BAR_HEIGHT = WINDOW_PX_SIZE;
-constexpr unsigned int EVAL_BAR_WIDTH =
-    static_cast<unsigned int>(static_cast<float>(WINDOW_PX_SIZE) * 0.1);
+inline unsigned int EVAL_BAR_HEIGHT = WINDOW_PX_SIZE;
+inline unsigned int EVAL_BAR_WIDTH = BOARD_OFFSET_X;
 
-constexpr unsigned int HOVER_PX_SIZE = SQUARE_PX_SIZE;
+inline unsigned int HOVER_PX_SIZE = SQUARE_PX_SIZE;
 
-constexpr float ANIM_SNAP_SPEED = .005f;
-constexpr float ANIM_MOVE_SPEED = .05f;
+inline float ANIM_SNAP_SPEED = .005f;
+inline float ANIM_MOVE_SPEED = .05f;
 
 const std::string STR_TEXTURE_WHITE = "white";
 const std::string STR_TEXTURE_BLACK = "black";
@@ -38,7 +44,7 @@ const std::string STR_FILE_PATH_HAND_OPEN = "assets/textures/cursor_hand_open.pn
 const std::string STR_FILE_PATH_HAND_CLOSED = "assets/textures/cursor_hand_closed.png";
 
 const std::string ASSET_PIECES_FILE_PATH = "assets/textures";
-constexpr float ASSET_PIECE_SCALE = 1.6f;
+inline float ASSET_PIECE_SCALE = 1.6f;  // base scale for 100px squares
 
 const std::string ASSET_SFX_FILE_PATH = "assets/audio/sfx";
 const std::string SFX_PLAYER_MOVE_NAME = "player_move";
@@ -50,5 +56,26 @@ const std::string SFX_CHECK_NAME = "check";
 const std::string SFX_PROMOTION_NAME = "promotion";
 const std::string SFX_GAME_BEGINS_NAME = "game_begins";
 const std::string SFX_GAME_ENDS_NAME = "game_ends";
+
+inline void updateWindowDimensions(unsigned int width, unsigned int height) {
+  WINDOW_WIDTH = width;
+  WINDOW_HEIGHT = height;
+  const unsigned int minDim = std::min(width, height);
+  if (minDim > WINDOW_MARGIN * 2) {
+    WINDOW_PX_SIZE = minDim - WINDOW_MARGIN * 2;
+  } else {
+    WINDOW_PX_SIZE = minDim;
+  }
+  BOARD_OFFSET_X = (width > WINDOW_PX_SIZE) ? (width - WINDOW_PX_SIZE) / 2 : 0;
+  BOARD_OFFSET_Y = (height > WINDOW_PX_SIZE) ? (height - WINDOW_PX_SIZE) / 2 : 0;
+  SQUARE_PX_SIZE = WINDOW_PX_SIZE / BOARD_SIZE;
+  ATTACK_DOT_PX_SIZE =
+      static_cast<unsigned int>(static_cast<float>(SQUARE_PX_SIZE) * 0.45f + 0.5f);
+  CAPTURE_CIRCLE_PX_SIZE =
+      static_cast<unsigned int>(static_cast<float>(SQUARE_PX_SIZE) * 1.02f + 0.5f);
+  EVAL_BAR_HEIGHT = WINDOW_PX_SIZE;
+  EVAL_BAR_WIDTH = BOARD_OFFSET_X;
+  HOVER_PX_SIZE = SQUARE_PX_SIZE;
+}
 
 }  // namespace lilia::view::constant

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -104,9 +104,12 @@ int App::run() {
   engine::Engine::init();
   lilia::view::TextureTable::getInstance().preLoad();
 
-  sf::RenderWindow window(
-      sf::VideoMode(lilia::view::constant::WINDOW_PX_SIZE, lilia::view::constant::WINDOW_PX_SIZE),
-      "Lilia", sf::Style::Titlebar | sf::Style::Close);
+    sf::RenderWindow window(
+        sf::VideoMode(lilia::view::constant::WINDOW_WIDTH,
+                      lilia::view::constant::WINDOW_HEIGHT),
+        "Lilia", sf::Style::Titlebar | sf::Style::Close | sf::Style::Resize);
+
+    lilia::view::constant::updateWindowDimensions(window.getSize().x, window.getSize().y);
 
   {
     lilia::model::ChessGame chessGame;
@@ -120,10 +123,15 @@ int App::run() {
     while (window.isOpen()) {
       float deltaSeconds = clock.restart().asSeconds();
       sf::Event event;
-      while (window.pollEvent(event)) {
-        if (event.type == sf::Event::Closed) window.close();
-        gameController.handleEvent(event);
-      }
+        while (window.pollEvent(event)) {
+          if (event.type == sf::Event::Closed) window.close();
+          if (event.type == sf::Event::Resized) {
+            lilia::view::constant::updateWindowDimensions(event.size.width,
+                                                          event.size.height);
+            gameView.resize(window.getSize());
+          }
+          gameController.handleEvent(event);
+        }
       gameController.update(deltaSeconds);
       window.clear(sf::Color::Blue);
       gameController.render();

--- a/src/lilia/view/board.cpp
+++ b/src/lilia/view/board.cpp
@@ -9,6 +9,7 @@ Board::Board(Entity::Position pos) : Entity(pos) {}
 void Board::init(const sf::Texture &textureWhite, const sf::Texture &textureBlack,
                  const sf::Texture &textureBoard) {
   setTexture(textureBoard);
+  setOriginToCenter();
   setScale(constant::WINDOW_PX_SIZE, constant::WINDOW_PX_SIZE);
 
   sf::Vector2f board_offset(

--- a/src/lilia/view/board_view.cpp
+++ b/src/lilia/view/board_view.cpp
@@ -4,12 +4,25 @@
 
 namespace lilia::view {
 
-BoardView::BoardView() : m_board({constant::WINDOW_PX_SIZE / 2, constant::WINDOW_PX_SIZE / 2}) {}
+BoardView::BoardView()
+    : m_board({static_cast<float>(constant::BOARD_OFFSET_X) +
+                constant::WINDOW_PX_SIZE / 2.0f,
+               static_cast<float>(constant::BOARD_OFFSET_Y) +
+                constant::WINDOW_PX_SIZE / 2.0f}) {}
 
 void BoardView::init() {
   m_board.init(TextureTable::getInstance().get(constant::STR_TEXTURE_WHITE),
                TextureTable::getInstance().get(constant::STR_TEXTURE_BLACK),
                TextureTable::getInstance().get(constant::STR_TEXTURE_TRANSPARENT));
+}
+
+void BoardView::resize(const sf::Vector2u& windowSize) {
+  (void)windowSize;
+  m_board.setPosition({static_cast<float>(constant::BOARD_OFFSET_X) +
+                           constant::WINDOW_PX_SIZE / 2.0f,
+                       static_cast<float>(constant::BOARD_OFFSET_Y) +
+                           constant::WINDOW_PX_SIZE / 2.0f});
+  init();
 }
 
 void BoardView::renderBoard(sf::RenderWindow& window) {

--- a/src/lilia/view/eval_bar.cpp
+++ b/src/lilia/view/eval_bar.cpp
@@ -12,12 +12,13 @@ namespace lilia::view {
 
 EvalBar::EvalBar() : EvalBar::Entity() {
   setTexture(TextureTable::getInstance().get(constant::STR_TEXTURE_TRANSPARENT));
-  setScale(constant::EVAL_BAR_WIDTH, constant::EVAL_BAR_HEIGHT);
+  m_black_background.setTexture(
+      TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_WHITE));
+  m_white_fill_eval.setTexture(
+      TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_BLACK));
+  setScale(static_cast<float>(constant::EVAL_BAR_WIDTH),
+           static_cast<float>(constant::EVAL_BAR_HEIGHT));
   setOriginToCenter();
-  m_black_background.setTexture(TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_WHITE));
-  m_white_fill_eval.setTexture(TextureTable::getInstance().get(constant::STR_TEXTURE_EVAL_BLACK));
-  m_black_background.setScale(constant::EVAL_BAR_WIDTH, constant::EVAL_BAR_HEIGHT);
-  m_white_fill_eval.setScale(constant::EVAL_BAR_WIDTH, constant::EVAL_BAR_HEIGHT);
   m_black_background.setOriginToCenter();
   m_white_fill_eval.setOriginToCenter();
 }
@@ -26,6 +27,12 @@ void EvalBar::setPosition(const Entity::Position& pos) {
   Entity::setPosition(pos);
   m_black_background.setPosition(getPosition());
   m_white_fill_eval.setPosition(getPosition());
+}
+
+void EvalBar::setScale(float width, float height) {
+  Entity::setScale(width, height);
+  m_black_background.setScale(width, height);
+  m_white_fill_eval.setScale(width, height);
 }
 
 void EvalBar::render(sf::RenderWindow& window) {

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -7,13 +7,13 @@
 
 namespace lilia::view {
 
-GameView::GameView(sf::RenderWindow& window)
-    : m_window(window),
-      m_board_view(),
-      m_piece_manager(m_board_view),
-      m_highlight_manager(m_board_view),
-      m_chess_animator(m_board_view, m_piece_manager),
-      m_eval_bar() {
+  GameView::GameView(sf::RenderWindow& window)
+      : m_window(window),
+        m_board_view(),
+        m_piece_manager(m_board_view),
+        m_highlight_manager(m_board_view),
+        m_chess_animator(m_board_view, m_piece_manager),
+        m_eval_bar() {
   m_cursor_default.loadFromSystem(sf::Cursor::Arrow);
 
   sf::Image openImg;
@@ -27,7 +27,10 @@ GameView::GameView(sf::RenderWindow& window)
                                         {openImg.getSize().x / 2, openImg.getSize().y / 2});
   }
   m_window.setMouseCursor(m_cursor_default);
-  m_eval_bar.setPosition(Entity::Position{0, constant::WINDOW_PX_SIZE / 2});
+  m_eval_bar.setPosition(
+      Entity::Position{static_cast<float>(constant::EVAL_BAR_WIDTH) / 2.0f,
+                        static_cast<float>(constant::BOARD_OFFSET_Y) +
+                            constant::WINDOW_PX_SIZE / 2.0f});
 }
 
 void GameView::init(const std::string& fen) {
@@ -43,7 +46,7 @@ void GameView::updateEval(int eval) {
   m_eval_bar.update(eval);
 }
 
-void GameView::render() {
+  void GameView::render() {
   m_board_view.renderBoard(m_window);
   m_highlight_manager.renderSelect(m_window);
   m_chess_animator.renderHighlightLevel(m_window);
@@ -160,6 +163,18 @@ void GameView::showGameOver(core::GameResult res, core::Color sideToMove) {
   std::cout << std::endl;
 }
 
+void GameView::resize(const sf::Vector2u& windowSize) {
+  m_board_view.resize(windowSize);
+  m_piece_manager.resizePieces();
+  m_highlight_manager.resize();
+  m_eval_bar.setScale(static_cast<float>(constant::EVAL_BAR_WIDTH),
+                      static_cast<float>(constant::EVAL_BAR_HEIGHT));
+  m_eval_bar.setPosition(
+      Entity::Position{static_cast<float>(constant::EVAL_BAR_WIDTH) / 2.0f,
+                        static_cast<float>(constant::BOARD_OFFSET_Y) +
+                            constant::WINDOW_PX_SIZE / 2.0f});
+}
+
 static inline int normalizeUnsignedToSigned(unsigned int u) {
   // Mappe 0..INT_MAX -> 0..INT_MAX, und (INT_MAX+1 .. UINT_MAX) -> negative Werte
   if (u <= static_cast<unsigned int>(std::numeric_limits<int>::max())) return static_cast<int>(u);
@@ -191,8 +206,11 @@ core::MousePos GameView::clampPosToWindowSize(core::MousePos mousePos) const noe
 }
 
 [[nodiscard]] core::Square GameView::mousePosToSquare(core::MousePos mousePos) const {
-  int file = clampPosToWindowSize(mousePos).x / constant::SQUARE_PX_SIZE;
-  int rankSFML = clampPosToWindowSize(mousePos).y / constant::SQUARE_PX_SIZE;
+    const auto clamped = clampPosToWindowSize(mousePos);
+    int file = (static_cast<int>(clamped.x) - static_cast<int>(constant::BOARD_OFFSET_X)) /
+               static_cast<int>(constant::SQUARE_PX_SIZE);
+    int rankSFML = (static_cast<int>(clamped.y) - static_cast<int>(constant::BOARD_OFFSET_Y)) /
+                   static_cast<int>(constant::SQUARE_PX_SIZE);
 
   int rankFromWhite = 7 - rankSFML;
 

--- a/src/lilia/view/highlight_manager.cpp
+++ b/src/lilia/view/highlight_manager.cpp
@@ -61,4 +61,15 @@ void HighlightManager::clearHighlightHoverSquare(core::Square pos) {
   m_hl_hover_squares.erase(pos);
 }
 
+void HighlightManager::resize() {
+  auto rescale = [](auto& map) {
+    for (auto& pair : map) {
+      pair.second.setScale(constant::SQUARE_PX_SIZE, constant::SQUARE_PX_SIZE);
+    }
+  };
+  rescale(m_hl_attack_squares);
+  rescale(m_hl_select_squares);
+  rescale(m_hl_hover_squares);
+}
+
 }  // namespace lilia::view

--- a/src/lilia/view/piece_manager.cpp
+++ b/src/lilia/view/piece_manager.cpp
@@ -77,7 +77,9 @@ void PieceManager::addPiece(core::PieceType type, core::Color color, core::Squar
   const sf::Texture& texture = TextureTable::getInstance().get(filename);
 
   Piece newpiece(color, type, texture);
-  newpiece.setScale(constant::ASSET_PIECE_SCALE, constant::ASSET_PIECE_SCALE);
+    float scale = constant::ASSET_PIECE_SCALE *
+                  (static_cast<float>(constant::SQUARE_PX_SIZE) / 100.f);
+    newpiece.setScale(scale, scale);
   m_pieces[pos] = std::move(newpiece);
   m_pieces[pos].setPosition(createPiecePositon(pos));
 }
@@ -140,6 +142,15 @@ void PieceManager::renderPieces(sf::RenderWindow& window,
 
 void PieceManager::renderPiece(core::Square pos, sf::RenderWindow& window) {
   m_pieces.find(pos)->second.draw(window);
+}
+
+void PieceManager::resizePieces() {
+  float scale = constant::ASSET_PIECE_SCALE *
+                (static_cast<float>(constant::SQUARE_PX_SIZE) / 100.f);
+  for (auto& pair : m_pieces) {
+    pair.second.setScale(scale, scale);
+    pair.second.setPosition(createPiecePositon(pair.first));
+  }
 }
 
 }  // namespace lilia::view


### PR DESCRIPTION
## Summary
- Increase default window dimensions to leave a margin around the board
- Place evaluation bar in the left margin and keep it sized with the board
- Recompute render constants so evaluation bar width matches board offset

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b33583d00c83298111a681eccfd7e6