### PR TITLE
Tweak eval bar positioning and restrict piece dragging

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -31,7 +31,6 @@ class GameView {
   void render();
 
   void addMove(const std::string& move);
-  void onResize(unsigned int width, unsigned int height);
   void scrollMoveList(float delta);
 
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
@@ -74,7 +73,7 @@ class GameView {
   void setHandClosedCursor();
 
  private:
-  core::MousePos clampPosToWindowSize(core::MousePos mousePos) const noexcept;
+  core::MousePos clampPosToBoard(core::MousePos mousePos) const noexcept;
   void layout(unsigned int width, unsigned int height);
 
   sf::RenderWindow& m_window;

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -12,7 +12,7 @@ constexpr unsigned int CAPTURE_CIRCLE_PX_SIZE =
 
 constexpr unsigned int EVAL_BAR_HEIGHT = WINDOW_PX_SIZE;
 constexpr unsigned int EVAL_BAR_WIDTH =
-    static_cast<unsigned int>(static_cast<float>(WINDOW_PX_SIZE) * 0.1);
+    static_cast<unsigned int>(static_cast<float>(WINDOW_PX_SIZE) * 0.05f);
 
 // Breite des Bereichs für die Zugliste rechts neben dem Brett
 constexpr unsigned int MOVE_LIST_WIDTH =

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -107,7 +107,7 @@ int App::run() {
   sf::RenderWindow window(
       sf::VideoMode(lilia::view::constant::WINDOW_TOTAL_WIDTH,
                     lilia::view::constant::WINDOW_TOTAL_HEIGHT),
-      "Lilia", sf::Style::Titlebar | sf::Style::Resize | sf::Style::Close);
+      "Lilia", sf::Style::Titlebar | sf::Style::Close);
 
   {
     lilia::model::ChessGame chessGame;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -96,9 +96,6 @@ void GameController::handleEvent(const sf::Event& event) {
     case sf::Event::MouseWheelScrolled:
       m_game_view.scrollMoveList(event.mouseWheelScroll.delta);
       break;
-    case sf::Event::Resized:
-      m_game_view.onResize(event.size.width, event.size.height);
-      break;
     default:
       break;
   }


### PR DESCRIPTION
## Summary
- slim eval bar and center it between the board and window
- clamp dragged piece positions inside board bounds
- remove window resizing support and resize event handling

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: undefined reference to `XOpenDisplay` and other X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b354b0f02c83298ee4fb0ef58b3150