### PR TITLE
Fix move list rendering and add navigation sound

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -100,6 +100,7 @@ void GameController::handleEvent(const sf::Event& event) {
           m_game_view.selectMove(static_cast<std::size_t>(-1));
         else
           m_game_view.selectMove(m_fen_index - 1);
+        m_sound_manager.playPlayerMove();
       }
       return;
     } else if (event.key.code == sf::Keyboard::Right) {
@@ -107,6 +108,7 @@ void GameController::handleEvent(const sf::Event& event) {
         ++m_fen_index;
         m_game_view.setBoardFen(m_fen_history[m_fen_index]);
         m_game_view.selectMove(m_fen_index - 1);
+        m_sound_manager.playPlayerMove();
       }
       return;
     }

--- a/src/lilia/view/move_list_view.cpp
+++ b/src/lilia/view/move_list_view.cpp
@@ -57,25 +57,26 @@ void MoveListView::render(sf::RenderWindow& window) const {
                               static_cast<float>(m_height)));
   window.setView(view);
 
-  const float top = 0.f;
-  const float bottom = static_cast<float>(m_height);
+  const float top = m_position.y;
+  const float bottom = m_position.y + static_cast<float>(m_height);
 
   // Zeichne nur sichtbare Zeilen
   for (std::size_t i = 0; i < m_lines.size(); ++i) {
-    const float y = kPaddingY + (static_cast<float>(i) * kLineHeight) - m_scroll_offset;
+    const float y = m_position.y + kPaddingY +
+                    (static_cast<float>(i) * kLineHeight) - m_scroll_offset;
     if (y + kLineHeight < top || y > bottom) continue;
 
     if (m_selected_move != static_cast<std::size_t>(-1) &&
         i == m_selected_move / 2) {
       sf::RectangleShape hl({static_cast<float>(m_width), kLineHeight});
-      hl.setPosition(0.f, y);
+      hl.setPosition(m_position.x, y);
       hl.setFillColor(sf::Color(80, 80, 80));
       window.draw(hl);
     }
 
     sf::Text text(m_lines[i], m_font, kFontSize);
     text.setFillColor(sf::Color::White);
-    text.setPosition(kPaddingX, y);
+    text.setPosition(m_position.x + kPaddingX, y);
     window.draw(text);
   }
 


### PR DESCRIPTION
## Summary
- Fix move list text positioning so moves render correctly
- Play move sound when stepping through move history

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL/OpenAL/VORBIS/FLAC -> installed dependencies -> link errors with X11)*
- `cmake --build build` *(fails: undefined reference to numerous X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b3606f3a20832983d29613c8056538