### PR TITLE
Add basic graphical start screen to select players and bots

### DIFF
--- a/include/lilia/app/app.hpp
+++ b/include/lilia/app/app.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "../chess_types.hpp"
+#include "../constants.hpp"
 
 namespace lilia::app {
 
@@ -12,23 +13,12 @@ class App {
   int run();
 
  private:
-  void promptStartOptions();
-
-  // input helper: parse integer with defaults and bounds
-  static int parseIntInRange(const std::string& s, int defaultVal, int minVal, int maxVal);
-
-  // helpers
-
-  static std::string trim(const std::string& s);
-  static std::string toLower(const std::string& s);
-  static bool parseYesNo(const std::string& s, bool defaultVal);
-
-  // parsed options
   bool m_white_is_bot = false;
   bool m_black_is_bot = true;
-  std::string m_start_fen;
+  std::string m_start_fen = core::START_FEN;
   int m_thinkTimeMs = 10000;  // Bot think time in milliseconds
   int m_searchDepth = 10;     // Search depth for bot
 };
 
 }  // namespace lilia::app
+

--- a/include/lilia/view/start_screen.hpp
+++ b/include/lilia/view/start_screen.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+#include <vector>
+
+#include "lilia/bot/bot_info.hpp"
+
+namespace lilia::view {
+
+struct StartConfig {
+  bool whiteIsBot{false};
+  BotType whiteBot{BotType::Lilia};
+  bool blackIsBot{true};
+  BotType blackBot{BotType::Lilia};
+};
+
+class StartScreen {
+ public:
+  explicit StartScreen(sf::RenderWindow &window);
+  StartConfig run();
+
+ private:
+  sf::RenderWindow &m_window;
+  sf::Font m_font;
+  sf::Texture m_logoTex;
+  sf::Sprite m_logo;
+  sf::Text m_title;
+
+  sf::RectangleShape m_whitePlayerBtn;
+  sf::RectangleShape m_whiteBotBtn;
+  sf::Text m_whitePlayerText;
+  sf::Text m_whiteBotText;
+  std::vector<std::pair<BotType, sf::Text>> m_whiteBotOptions;
+  std::size_t m_whiteBotSelection{0};
+
+  sf::RectangleShape m_blackPlayerBtn;
+  sf::RectangleShape m_blackBotBtn;
+  sf::Text m_blackPlayerText;
+  sf::Text m_blackBotText;
+  std::vector<std::pair<BotType, sf::Text>> m_blackBotOptions;
+  std::size_t m_blackBotSelection{0};
+
+  sf::RectangleShape m_startBtn;
+  sf::Text m_startText;
+
+  void setupUI();
+  bool handleMouse(sf::Vector2f pos, StartConfig &cfg);
+};
+
+}  // namespace lilia::view
+

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -2,119 +2,37 @@
 
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Window/Event.hpp>
-#include <algorithm>
-#include <cctype>
-#include <iostream>
 
 #include "lilia/controller/game_controller.hpp"
 #include "lilia/engine/engine.hpp"
 #include "lilia/model/chess_game.hpp"
 #include "lilia/view/game_view.hpp"
+#include "lilia/view/start_screen.hpp"
 #include "lilia/view/texture_table.hpp"
 
 namespace lilia::app {
 
-std::string App::trim(const std::string& s) {
-  size_t start = 0;
-  while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start]))) ++start;
-  size_t end = s.size();
-  while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1]))) --end;
-  return s.substr(start, end - start);
-}
-
-std::string App::toLower(const std::string& s) {
-  std::string out = s;
-  std::transform(out.begin(), out.end(), out.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-  return out;
-}
-
-bool App::parseYesNo(const std::string& s, bool defaultVal) {
-  if (s.empty()) return defaultVal;
-  std::string normalized = toLower(trim(s));
-  if (normalized == "y" || normalized == "yes" || normalized == "1" || normalized == "true")
-    return true;
-  if (normalized == "n" || normalized == "no" || normalized == "0" || normalized == "false")
-    return false;
-  return defaultVal;
-}
-
-int App::parseIntInRange(const std::string& s, int defaultVal, int minVal, int maxVal) {
-  std::string t = trim(s);
-  if (t.empty()) return defaultVal;
-  if (!std::all_of(t.begin(), t.end(), [](unsigned char c) { return std::isdigit(c); })) return -1;
-  int val = std::stoi(t);
-  if (val < minVal || val > maxVal) return -1;
-  return val;
-}
-
-void App::promptStartOptions() {
-  std::cout << "Is white a bot? (yes / no) [Standard: no]: ";
-  std::string whiteBotInput;
-  std::getline(std::cin, whiteBotInput);
-  m_white_is_bot = parseYesNo(whiteBotInput, false);
-
-  std::cout << "Is black a bot? (yes / no) [Standard: yes]: ";
-  std::string blackBotInput;
-  std::getline(std::cin, blackBotInput);
-  m_black_is_bot = parseYesNo(blackBotInput, true);
-
-  std::cout << "Startposition as FEN [empty = Standard-Start]: ";
-  std::string fenInput;
-  std::getline(std::cin, fenInput);
-  std::string fenTrim = trim(fenInput);
-  if (fenTrim.empty()) {
-    m_start_fen = core::START_FEN;
-  } else {
-    m_start_fen = fenInput;  // use exactly what the user typed (trimmed)
-  }
-
-  // Think time in seconds
-  while (true) {
-    int thinkSec = m_thinkTimeMs / 1000;
-    std::cout << "Bot think time in seconds [Standard: " << thinkSec << "]: ";
-    std::string thinkInput;
-    std::getline(std::cin, thinkInput);
-    int val = parseIntInRange(thinkInput, thinkSec, 1, 60);
-    if (val != -1) {
-      m_thinkTimeMs = val * 1000;
-      break;
-    }
-    std::cout << "Please enter a number between 1 and 60.\n";
-  }
-
-  // Search depth
-  while (true) {
-    std::cout << "Bot search depth [Standard: " << m_searchDepth << "]: ";
-    std::string depthInput;
-    std::getline(std::cin, depthInput);
-    int val = parseIntInRange(depthInput, m_searchDepth, 1, 20);
-    if (val != -1) {
-      m_searchDepth = val;
-      break;
-    }
-    std::cout << "Please enter a number between 1 and 20.\n";
-  }
-}
-
 int App::run() {
-  promptStartOptions();
-
   engine::Engine::init();
   lilia::view::TextureTable::getInstance().preLoad();
 
-  sf::RenderWindow window(sf::VideoMode(lilia::view::constant::WINDOW_TOTAL_WIDTH,
-                                        lilia::view::constant::WINDOW_TOTAL_HEIGHT),
-                          "Lilia", sf::Style::Titlebar | sf::Style::Close);
+  sf::RenderWindow window(
+      sf::VideoMode(lilia::view::constant::WINDOW_TOTAL_WIDTH,
+                    lilia::view::constant::WINDOW_TOTAL_HEIGHT),
+      "Lilia", sf::Style::Titlebar | sf::Style::Close);
+
+  lilia::view::StartScreen startScreen(window);
+  auto cfg = startScreen.run();
+  m_white_is_bot = cfg.whiteIsBot;
+  m_black_is_bot = cfg.blackIsBot;
 
   {
     lilia::model::ChessGame chessGame;
     lilia::view::GameView gameView(window, m_black_is_bot, m_white_is_bot);
     lilia::controller::GameController gameController(gameView, chessGame);
 
-    // start the game using GameController wrapper that delegates to GameManager
-    gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot, m_thinkTimeMs,
-                             m_searchDepth);
+    gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot,
+                             m_thinkTimeMs, m_searchDepth);
 
     sf::Clock clock;
     while (window.isOpen()) {
@@ -135,3 +53,4 @@ int App::run() {
 }
 
 }  // namespace lilia::app
+

--- a/src/lilia/view/start_screen.cpp
+++ b/src/lilia/view/start_screen.cpp
@@ -1,0 +1,199 @@
+#include "lilia/view/start_screen.hpp"
+
+#include "lilia/view/render_constants.hpp"
+#include <SFML/Window/Event.hpp>
+
+namespace lilia::view {
+
+StartScreen::StartScreen(sf::RenderWindow &window) : m_window(window) {
+  m_font.loadFromFile(constant::STR_FILE_PATH_FONT);
+  m_logoTex.loadFromFile(constant::STR_FILE_PATH_ICON_LILIA);
+  m_logo.setTexture(m_logoTex);
+  m_logo.setOrigin(m_logo.getLocalBounds().width / 2.f,
+                   m_logo.getLocalBounds().height / 2.f);
+  m_logo.setPosition(static_cast<float>(m_window.getSize().x) / 2.f, 80.f);
+
+  m_title.setFont(m_font);
+  m_title.setString("Lilia Engine");
+  m_title.setCharacterSize(24);
+  m_title.setFillColor(sf::Color::White);
+  m_title.setOrigin(m_title.getLocalBounds().width / 2.f,
+                    m_title.getLocalBounds().height / 2.f);
+  m_title.setPosition(static_cast<float>(m_window.getSize().x) / 2.f, 140.f);
+
+  setupUI();
+}
+
+void StartScreen::setupUI() {
+  float width = static_cast<float>(m_window.getSize().x);
+  float height = static_cast<float>(m_window.getSize().y);
+
+  sf::Vector2f btnSize(180.f, 50.f);
+  float leftX = width * 0.25f - btnSize.x / 2.f;
+  float rightX = width * 0.75f - btnSize.x / 2.f;
+  float baseY = 220.f;
+
+  m_whitePlayerBtn.setSize(btnSize);
+  m_whitePlayerBtn.setPosition(leftX, baseY);
+  m_whitePlayerText.setFont(m_font);
+  m_whitePlayerText.setString("Player");
+  m_whitePlayerText.setCharacterSize(20);
+  m_whitePlayerText.setFillColor(sf::Color::Black);
+  m_whitePlayerText.setPosition(leftX + 20.f, baseY + 12.f);
+
+  m_whiteBotBtn.setSize(btnSize);
+  m_whiteBotBtn.setPosition(leftX, baseY + 70.f);
+  m_whiteBotText.setFont(m_font);
+  m_whiteBotText.setString("Bot");
+  m_whiteBotText.setCharacterSize(20);
+  m_whiteBotText.setFillColor(sf::Color::Black);
+  m_whiteBotText.setPosition(leftX + 20.f, baseY + 82.f);
+
+  m_blackPlayerBtn.setSize(btnSize);
+  m_blackPlayerBtn.setPosition(rightX, baseY);
+  m_blackPlayerText.setFont(m_font);
+  m_blackPlayerText.setString("Player");
+  m_blackPlayerText.setCharacterSize(20);
+  m_blackPlayerText.setFillColor(sf::Color::Black);
+  m_blackPlayerText.setPosition(rightX + 20.f, baseY + 12.f);
+
+  m_blackBotBtn.setSize(btnSize);
+  m_blackBotBtn.setPosition(rightX, baseY + 70.f);
+  m_blackBotText.setFont(m_font);
+  m_blackBotText.setString("Bot");
+  m_blackBotText.setCharacterSize(20);
+  m_blackBotText.setFillColor(sf::Color::Black);
+  m_blackBotText.setPosition(rightX + 20.f, baseY + 82.f);
+
+  // prepare bot list
+  std::vector<std::pair<BotType, PlayerInfo>> bots = {
+      {BotType::Lilia, getBotInfo(BotType::Lilia)}};
+
+  float listYOffset = baseY + 140.f;
+  for (std::size_t i = 0; i < bots.size(); ++i) {
+    sf::Text t;
+    t.setFont(m_font);
+    t.setString(bots[i].second.name);
+    t.setCharacterSize(20);
+    t.setFillColor(sf::Color::White);
+    t.setPosition(leftX, listYOffset + i * 30.f);
+    m_whiteBotOptions.push_back({bots[i].first, t});
+
+    sf::Text t2 = t;
+    t2.setPosition(rightX, listYOffset + i * 30.f);
+    m_blackBotOptions.push_back({bots[i].first, t2});
+  }
+
+  m_startBtn.setSize(sf::Vector2f(200.f, 60.f));
+  m_startBtn.setOrigin(100.f, 30.f);
+  m_startBtn.setPosition(width / 2.f, height - 100.f);
+  m_startText.setFont(m_font);
+  m_startText.setString("Start");
+  m_startText.setCharacterSize(24);
+  m_startText.setFillColor(sf::Color::Black);
+  m_startText.setOrigin(m_startText.getLocalBounds().width / 2.f,
+                        m_startText.getLocalBounds().height / 2.f);
+  m_startText.setPosition(m_startBtn.getPosition());
+}
+
+bool StartScreen::handleMouse(sf::Vector2f pos, StartConfig &cfg) {
+  if (m_whitePlayerBtn.getGlobalBounds().contains(pos)) {
+    cfg.whiteIsBot = false;
+  } else if (m_whiteBotBtn.getGlobalBounds().contains(pos)) {
+    cfg.whiteIsBot = true;
+  } else if (cfg.whiteIsBot) {
+    for (std::size_t i = 0; i < m_whiteBotOptions.size(); ++i) {
+      if (m_whiteBotOptions[i].second.getGlobalBounds().contains(pos)) {
+        m_whiteBotSelection = i;
+        cfg.whiteBot = m_whiteBotOptions[i].first;
+      }
+    }
+  }
+
+  if (m_blackPlayerBtn.getGlobalBounds().contains(pos)) {
+    cfg.blackIsBot = false;
+  } else if (m_blackBotBtn.getGlobalBounds().contains(pos)) {
+    cfg.blackIsBot = true;
+  } else if (cfg.blackIsBot) {
+    for (std::size_t i = 0; i < m_blackBotOptions.size(); ++i) {
+      if (m_blackBotOptions[i].second.getGlobalBounds().contains(pos)) {
+        m_blackBotSelection = i;
+        cfg.blackBot = m_blackBotOptions[i].first;
+      }
+    }
+  }
+
+  if (m_startBtn.getGlobalBounds().contains(pos)) {
+    return true;
+  }
+  return false;
+}
+
+StartConfig StartScreen::run() {
+  StartConfig cfg;
+  bool startGame = false;
+  while (m_window.isOpen() && !startGame) {
+    sf::Event event;
+    while (m_window.pollEvent(event)) {
+      if (event.type == sf::Event::Closed) {
+        m_window.close();
+      } else if (event.type == sf::Event::MouseButtonPressed &&
+                 event.mouseButton.button == sf::Mouse::Left) {
+        sf::Vector2f pos = m_window.mapPixelToCoords({event.mouseButton.x, event.mouseButton.y});
+        startGame = handleMouse(pos, cfg);
+      }
+    }
+
+    m_whitePlayerBtn.setFillColor(cfg.whiteIsBot ? sf::Color(100, 100, 100)
+                                                 : sf::Color(200, 200, 200));
+    m_whiteBotBtn.setFillColor(cfg.whiteIsBot ? sf::Color(200, 200, 200)
+                                             : sf::Color(100, 100, 100));
+    m_blackPlayerBtn.setFillColor(cfg.blackIsBot ? sf::Color(100, 100, 100)
+                                                 : sf::Color(200, 200, 200));
+    m_blackBotBtn.setFillColor(cfg.blackIsBot ? sf::Color(200, 200, 200)
+                                             : sf::Color(100, 100, 100));
+
+    for (std::size_t i = 0; i < m_whiteBotOptions.size(); ++i) {
+      m_whiteBotOptions[i].second.setFillColor(
+          (cfg.whiteIsBot && i == m_whiteBotSelection) ? sf::Color::Yellow
+                                                       : sf::Color::White);
+    }
+    for (std::size_t i = 0; i < m_blackBotOptions.size(); ++i) {
+      m_blackBotOptions[i].second.setFillColor(
+          (cfg.blackIsBot && i == m_blackBotSelection) ? sf::Color::Yellow
+                                                        : sf::Color::White);
+    }
+
+    m_startBtn.setFillColor(sf::Color(200, 200, 200));
+
+    m_window.clear(sf::Color::Black);
+    m_window.draw(m_logo);
+    m_window.draw(m_title);
+
+    m_window.draw(m_whitePlayerBtn);
+    m_window.draw(m_whiteBotBtn);
+    m_window.draw(m_whitePlayerText);
+    m_window.draw(m_whiteBotText);
+    if (cfg.whiteIsBot) {
+      for (auto &t : m_whiteBotOptions) m_window.draw(t.second);
+    }
+
+    m_window.draw(m_blackPlayerBtn);
+    m_window.draw(m_blackBotBtn);
+    m_window.draw(m_blackPlayerText);
+    m_window.draw(m_blackBotText);
+    if (cfg.blackIsBot) {
+      for (auto &t : m_blackBotOptions) m_window.draw(t.second);
+    }
+
+    m_window.draw(m_startBtn);
+    m_window.draw(m_startText);
+
+    m_window.display();
+  }
+
+  return cfg;
+}
+
+}  // namespace lilia::view
+


### PR DESCRIPTION
## Summary
- Introduce `StartScreen` view that lets users choose human or bot players for each color before launching the game
- Replace console prompts in `App` with the new start screen and set default game options

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build --target lilia_app -j2` *(fails: undefined reference to Xlib functions)*

------
https://chatgpt.com/codex/tasks/task_e_68b3eac54fe483299ab867b574899879