### PR TITLE
Fix rematch behavior and post-game interactions

### DIFF
--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -31,6 +31,7 @@ int App::run() {
         lilia::controller::GameController::NextAction::None;
 
     do {
+      action = lilia::controller::GameController::NextAction::None;
       lilia::model::ChessGame chessGame;
       lilia::view::GameView gameView(window, m_black_is_bot, m_white_is_bot);
       lilia::controller::GameController gameController(gameView, chessGame);

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -87,6 +87,9 @@ GameController::~GameController() = default;
 void GameController::startGame(const std::string &fen, bool whiteIsBot,
                                bool blackIsBot, int think_time_ms, int depth) {
   m_sound_manager.playEffect(view::sound::Effect::GameBegins);
+  m_game_view.hideResignPopup();
+  m_game_view.hideGameOverPopup();
+  m_game_view.setGameOver(false);
   m_game_view.init(fen);
   m_game_view.setBotMode(whiteIsBot || blackIsBot);
   m_game_manager->startGame(fen, whiteIsBot, blackIsBot, think_time_ms, depth);
@@ -186,9 +189,6 @@ void GameController::handleEvent(const sf::Event &event) {
     }
   }
 
-  if (m_chess_game.getResult() != core::GameResult::ONGOING)
-    return;
-
   if (event.type == sf::Event::MouseWheelScrolled) {
     m_game_view.scrollMoveList(event.mouseWheelScroll.delta);
     if (m_fen_index != m_fen_history.size() - 1)
@@ -205,6 +205,9 @@ void GameController::handleEvent(const sf::Event &event) {
     }
   }
   if (m_fen_index != m_fen_history.size() - 1)
+    return;
+
+  if (m_chess_game.getResult() != core::GameResult::ONGOING)
     return;
 
   switch (event.type) {


### PR DESCRIPTION
## Summary
- Reset popups and game-over state when starting a new game to enable proper rematches
- Allow UI interactions like scrolling or navigating moves even after the game ends while keeping pieces immovable
- Ensure rematch loops restart cleanly by clearing next-action state each iteration

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b4668942bc83298563b53f675a6cc4