### PR TITLE
Reset game state when starting new ChessGame

### DIFF
--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -67,6 +67,12 @@ std::optional<Move> ChessGame::getMove(core::Square from, core::Square to) {
 }
 
 void ChessGame::setPosition(const std::string& fen) {
+  // Reset to a fresh game state so old pieces or metadata do not persist
+  m_position = Position{};
+  m_result = core::GameResult::ONGOING;
+  m_pseudo_moves.clear();
+  m_legal_moves.clear();
+
   std::istringstream iss(fen);
   std::string board, activeColor, castling, enPassant, halfmoveClock, fullmoveNumber;
 


### PR DESCRIPTION
## Summary
- Clear board and state when loading a FEN to avoid carrying over old game data

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_engine -j 4`


------
https://chatgpt.com/codex/tasks/task_e_68b4690f75cc8329b5ce2699e3cbb88f