### PR TITLE
Clamp drag positions within board bounds

### DIFF
--- a/include/lilia/view/board_view.hpp
+++ b/include/lilia/view/board_view.hpp
@@ -18,7 +18,8 @@ public:
   void setFlipped(bool flipped);
   [[nodiscard]] bool isFlipped() const;
   [[nodiscard]] bool isOnFlipIcon(core::MousePos mousePos) const;
-  core::MousePos clampPosToBoard(core::MousePos mousePos) const noexcept;
+  core::MousePos clampPosToBoard(core::MousePos mousePos,
+                                 Entity::Position pieceSize = {0.f, 0.f}) const noexcept;
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
 
   void setPosition(const Entity::Position &pos);

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -60,6 +60,8 @@ public:
   [[nodiscard]] bool isOnRematch(core::MousePos mousePos) const;
 
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
+  [[nodiscard]] core::MousePos clampPosToBoard(
+      core::MousePos mousePos, Entity::Position pieceSize = {0.f, 0.f}) const;
   void setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos);
   void setPieceToSquareScreenPos(core::Square from, core::Square to);
 

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -608,7 +608,8 @@ void GameController::onClick(core::MousePos mousePos) {
 
 void GameController::onDrag(core::MousePos start, core::MousePos current) {
   const core::Square sqStart = m_game_view.mousePosToSquare(start);
-  const core::Square sqMous = m_game_view.mousePosToSquare(current);
+  const core::MousePos clamped = m_game_view.clampPosToBoard(current);
+  const core::Square sqMous = m_game_view.mousePosToSquare(clamped);
 
   if (m_game_view.isInPromotionSelection()) return;
   if (!m_game_view.hasPieceOnSquare(sqStart)) return;
@@ -631,7 +632,8 @@ void GameController::onDrag(core::MousePos start, core::MousePos current) {
 
 void GameController::onDrop(core::MousePos start, core::MousePos end) {
   const core::Square from = m_game_view.mousePosToSquare(start);
-  const core::Square to = m_game_view.mousePosToSquare(end);
+  const core::Square to =
+      m_game_view.mousePosToSquare(m_game_view.clampPosToBoard(end));
 
   dehoverSquare();
 

--- a/src/lilia/view/board_view.cpp
+++ b/src/lilia/view/board_view.cpp
@@ -85,17 +85,23 @@ constexpr int clampInt(int v, int lo, int hi) noexcept {
 } // namespace
 
 core::MousePos
-BoardView::clampPosToBoard(core::MousePos mousePos) const noexcept {
+BoardView::clampPosToBoard(core::MousePos mousePos,
+                            Entity::Position pieceSize) const noexcept {
   const int sx = normalizeUnsignedToSigned(mousePos.x);
   const int sy = normalizeUnsignedToSigned(mousePos.y);
 
   auto boardCenter = getPosition();
+  const float halfW = pieceSize.x / 2.f;
+  const float halfH = pieceSize.y / 2.f;
+
   const int left = static_cast<int>(
-      boardCenter.x - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f);
+      boardCenter.x - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f + halfW);
   const int top = static_cast<int>(
-      boardCenter.y - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f);
-  const int right = left + static_cast<int>(constant::WINDOW_PX_SIZE) - 1;
-  const int bottom = top + static_cast<int>(constant::WINDOW_PX_SIZE) - 1;
+      boardCenter.y - static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f + halfH);
+  const int right = static_cast<int>(
+      boardCenter.x + static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f - 1.f - halfW);
+  const int bottom = static_cast<int>(
+      boardCenter.y + static_cast<float>(constant::WINDOW_PX_SIZE) / 2.f - 1.f - halfH);
 
   const int cx = clampInt(sx, left, right);
   const int cy = clampInt(sy, top, bottom);

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -375,8 +375,14 @@ void GameView::removePromotionSelection() {
   return m_board_view.mousePosToSquare(mousePos);
 }
 
+core::MousePos GameView::clampPosToBoard(core::MousePos mousePos,
+                                         Entity::Position pieceSize) const {
+  return m_board_view.clampPosToBoard(mousePos, pieceSize);
+}
+
 void GameView::setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos) {
-  m_piece_manager.setPieceToScreenPos(pos, m_board_view.clampPosToBoard(mousePos));
+  auto size = getPieceSize(pos);
+  m_piece_manager.setPieceToScreenPos(pos, clampPosToBoard(mousePos, size));
 }
 void GameView::setPieceToSquareScreenPos(core::Square from, core::Square to) {
   m_piece_manager.setPieceToSquareScreenPos(from, to);


### PR DESCRIPTION
## Summary
- keep hover highlight in sync by converting clamped drag positions to board squares
- clamp dragged pieces using their size so they stay within board edges

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: undefined references to X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b46eb56a308329ba7d021eb6c6da29