### PR TITLE
Add time control and clock display

### DIFF
--- a/include/lilia/constants.hpp
+++ b/include/lilia/constants.hpp
@@ -4,5 +4,13 @@
 
 namespace lilia::core {
 const std::string START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-enum GameResult { ONGOING, CHECKMATE, REPETITION, MOVERULE, STALEMATE, INSUFFICIENT };
+enum GameResult {
+  ONGOING,
+  CHECKMATE,
+  TIMEOUT,
+  REPETITION,
+  MOVERULE,
+  STALEMATE,
+  INSUFFICIENT
+};
 }  

--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -18,6 +18,7 @@ class Event;
 #include "../view/audio/sound_manager.hpp"
 #include "../view/game_view.hpp"
 #include "input_manager.hpp"
+#include "time_controller.hpp"
 
 namespace lilia::model {
 class ChessGame;
@@ -63,7 +64,8 @@ public:
   void startGame(const std::string &fen = core::START_FEN,
                  bool whiteIsBot = false, bool blackIsBot = true,
                  int whiteThinkTimeMs = 1000, int whiteDepth = 5,
-                 int blackThinkTimeMs = 1000, int blackDepth = 5);
+                 int blackThinkTimeMs = 1000, int blackDepth = 5,
+                 int baseSeconds = 0, int incrementSeconds = 0);
 
   enum class NextAction { None, NewBot, Rematch };
   [[nodiscard]] NextAction getNextAction() const;
@@ -137,6 +139,7 @@ private:
 
   // ---------------- New: GameManager ----------------
   std::unique_ptr<GameManager> m_game_manager;
+  std::unique_ptr<TimeController> m_time_controller;
   std::atomic<int> m_eval_cp{0};
 
   std::vector<std::string> m_fen_history;

--- a/include/lilia/controller/time_controller.hpp
+++ b/include/lilia/controller/time_controller.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "lilia/chess_types.hpp"
+#include <optional>
+
+namespace lilia::controller {
+
+class TimeController {
+ public:
+  TimeController(int baseSeconds = 0, int incSeconds = 0);
+
+  void start(core::Color sideToMove);
+  void onMove(core::Color mover);
+  void update(float dt);
+
+  [[nodiscard]] float getTime(core::Color color) const;
+  [[nodiscard]] std::optional<core::Color> getFlagged() const;
+
+ private:
+  float m_white_time;
+  float m_black_time;
+  int m_increment;
+  core::Color m_active;
+  bool m_running{false};
+  std::optional<core::Color> m_flagged;
+};
+
+}  // namespace lilia::controller
+

--- a/include/lilia/view/clock.hpp
+++ b/include/lilia/view/clock.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <SFML/Graphics/RectangleShape.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/Text.hpp>
+
+#include "lilia/chess_types.hpp"
+#include "lilia/view/render_constants.hpp"
+
+namespace lilia::view {
+
+class Clock {
+ public:
+  Clock();
+
+  void setPlayerColor(core::Color color);
+  void setPosition(const sf::Vector2f& pos);
+  void setTime(float seconds);
+  void render(sf::RenderWindow& window);
+
+  static constexpr float WIDTH = 120.f;
+  static constexpr float HEIGHT = 40.f;
+
+ private:
+  sf::RectangleShape m_box;
+  sf::Text m_text;
+  sf::Font m_font;
+};
+
+}  // namespace lilia::view
+

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -20,6 +20,7 @@
 #include "piece_manager.hpp"
 #include "player_info_view.hpp"
 #include "promotion_manager.hpp"
+#include "clock.hpp"
 
 namespace lilia::view {
 
@@ -119,6 +120,8 @@ class GameView {
   void resetEvalBar();
   void setEvalResult(const std::string &result);
 
+  void updateClock(core::Color color, float seconds);
+
  private:
   void layout(unsigned int width, unsigned int height);
 
@@ -142,6 +145,10 @@ class GameView {
   PlayerInfoView m_bottom_player;
   PlayerInfoView* m_white_player{};
   PlayerInfoView* m_black_player{};
+  Clock m_top_clock;
+  Clock m_bottom_clock;
+  Clock* m_white_clock{};
+  Clock* m_black_clock{};
   ModalView m_modal;  // ← replaces ad-hoc popup fields
 
   // FX

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -41,6 +41,8 @@ int App::run() {
     bool m_white_is_bot = cfg.whiteIsBot;
     bool m_black_is_bot = cfg.blackIsBot;
     std::string m_start_fen = cfg.fen;
+    int baseSeconds = cfg.timeBaseSeconds;
+    int incrementSeconds = cfg.timeIncrementSeconds;
 
     auto whiteCfg = getBotConfig(cfg.whiteBot);
     auto blackCfg = getBotConfig(cfg.blackBot);
@@ -60,7 +62,7 @@ int App::run() {
 
       gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot,
                                whiteThinkMs, whiteDepth, blackThinkMs,
-                               blackDepth);
+                               blackDepth, baseSeconds, incrementSeconds);
 
       sf::Clock clock;
       while (window.isOpen() &&

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -27,6 +27,8 @@ inline std::string resultToString(core::GameResult res, core::Color sideToMove) 
   switch (res) {
   case core::GameResult::CHECKMATE:
     return (sideToMove == core::Color::White) ? "0-1" : "1-0";
+  case core::GameResult::TIMEOUT:
+    return (sideToMove == core::Color::White) ? "0-1" : "1-0";
   case core::GameResult::REPETITION:
   case core::GameResult::MOVERULE:
   case core::GameResult::STALEMATE:
@@ -87,6 +89,11 @@ GameController::GameController(view::GameView &gView, model::ChessGame &game)
         this->m_game_view.selectMove(this->m_fen_index
                                            ? this->m_fen_index - 1
                                            : static_cast<std::size_t>(-1));
+        if (this->m_time_controller) {
+          core::Color mover =
+              ~this->m_chess_game.getGameState().sideToMove;
+          this->m_time_controller->onMove(mover);
+        }
       });
 
   m_game_manager->setOnPromotionRequested([this](core::Square sq) {
@@ -104,7 +111,8 @@ GameController::~GameController() = default;
 void GameController::startGame(const std::string &fen, bool whiteIsBot,
                                bool blackIsBot, int whiteThinkTimeMs,
                                int whiteDepth, int blackThinkTimeMs,
-                               int blackDepth) {
+                               int blackDepth, int baseSeconds,
+                               int incrementSeconds) {
   m_sound_manager.playEffect(view::sound::Effect::GameBegins);
   m_game_view.hideResignPopup();
   m_game_view.hideGameOverPopup();
@@ -113,6 +121,13 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot,
   m_game_view.setBotMode(whiteIsBot || blackIsBot);
   m_game_manager->startGame(fen, whiteIsBot, blackIsBot, whiteThinkTimeMs,
                             whiteDepth, blackThinkTimeMs, blackDepth);
+
+  m_time_controller =
+      std::make_unique<TimeController>(baseSeconds, incrementSeconds);
+  core::Color stm = m_chess_game.getGameState().sideToMove;
+  m_time_controller->start(stm);
+  m_game_view.updateClock(core::Color::White, static_cast<float>(baseSeconds));
+  m_game_view.updateClock(core::Color::Black, static_cast<float>(baseSeconds));
 
   m_fen_history.clear();
   m_eval_history.clear();
@@ -389,6 +404,21 @@ void GameController::update(float dt) {
   // the view
   if (m_chess_game.getResult() != core::GameResult::ONGOING)
     return;
+
+  if (m_time_controller) {
+    m_time_controller->update(dt);
+    m_game_view.updateClock(core::Color::White,
+                            m_time_controller->getTime(core::Color::White));
+    m_game_view.updateClock(core::Color::Black,
+                            m_time_controller->getTime(core::Color::Black));
+    if (auto flag = m_time_controller->getFlagged()) {
+      m_chess_game.setResult(core::GameResult::TIMEOUT);
+      if (m_game_manager)
+        m_game_manager->stopGame();
+      showGameOver(core::GameResult::TIMEOUT, *flag);
+      return;
+    }
+  }
 
   // Game logic continues only while ongoing
   if (m_game_manager)
@@ -871,6 +901,12 @@ void GameController::showGameOver(core::GameResult res,
     resultStr = (sideToMove == core::Color::White) ? "0-1" : "1-0";
     m_game_view.showGameOverPopup(
         sideToMove == core::Color::White ? "Black won" : "White won");
+    break;
+  case core::GameResult::TIMEOUT:
+    resultStr = (sideToMove == core::Color::White) ? "0-1" : "1-0";
+    m_game_view.showGameOverPopup(sideToMove == core::Color::White
+                                      ? "Black wins on time"
+                                      : "White wins on time");
     break;
   case core::GameResult::REPETITION:
     resultStr = "1/2-1/2";

--- a/src/lilia/controller/time_controller.cpp
+++ b/src/lilia/controller/time_controller.cpp
@@ -1,0 +1,44 @@
+#include "lilia/controller/time_controller.hpp"
+
+namespace lilia::controller {
+
+TimeController::TimeController(int baseSeconds, int incSeconds)
+    : m_white_time(static_cast<float>(baseSeconds)),
+      m_black_time(static_cast<float>(baseSeconds)),
+      m_increment(incSeconds),
+      m_active(core::Color::White) {}
+
+void TimeController::start(core::Color sideToMove) {
+  m_active = sideToMove;
+  m_running = true;
+  m_flagged.reset();
+}
+
+void TimeController::onMove(core::Color mover) {
+  if (!m_running || m_flagged)
+    return;
+  float &t = (mover == core::Color::White) ? m_white_time : m_black_time;
+  t += static_cast<float>(m_increment);
+  m_active = ~mover;
+}
+
+void TimeController::update(float dt) {
+  if (!m_running || m_flagged)
+    return;
+  float &t = (m_active == core::Color::White) ? m_white_time : m_black_time;
+  t -= dt;
+  if (t <= 0.f) {
+    t = 0.f;
+    m_flagged = m_active;
+    m_running = false;
+  }
+}
+
+float TimeController::getTime(core::Color color) const {
+  return (color == core::Color::White) ? m_white_time : m_black_time;
+}
+
+std::optional<core::Color> TimeController::getFlagged() const { return m_flagged; }
+
+}  // namespace lilia::controller
+

--- a/src/lilia/view/clock.cpp
+++ b/src/lilia/view/clock.cpp
@@ -1,0 +1,60 @@
+#include "lilia/view/clock.hpp"
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+namespace lilia::view {
+
+Clock::Clock() {
+  m_box.setSize({WIDTH, HEIGHT});
+  m_box.setOutlineThickness(2.f);
+  m_box.setOutlineColor(sf::Color(80, 80, 80));
+  m_font.loadFromFile(constant::STR_FILE_PATH_FONT);
+  m_text.setFont(m_font);
+  m_text.setCharacterSize(18);
+  m_text.setFillColor(sf::Color::Black);
+}
+
+void Clock::setPlayerColor(core::Color color) {
+  if (color == core::Color::White) {
+    m_box.setFillColor(sf::Color(230, 230, 230));
+    m_text.setFillColor(sf::Color::Black);
+  } else {
+    m_box.setFillColor(sf::Color(40, 40, 40));
+    m_text.setFillColor(sf::Color::White);
+  }
+}
+
+void Clock::setPosition(const sf::Vector2f& pos) {
+  m_box.setPosition(pos);
+  m_text.setPosition(pos.x + 10.f, pos.y + 8.f);
+}
+
+static std::string formatTime(float seconds) {
+  int s = static_cast<int>(seconds + 0.5f);
+  int h = s / 3600;
+  int m = (s % 3600) / 60;
+  int sec = s % 60;
+  std::ostringstream oss;
+  if (h > 0) {
+    oss << std::setw(2) << std::setfill('0') << h << ':' << std::setw(2)
+        << m << ':' << std::setw(2) << sec;
+  } else {
+    oss << std::setw(2) << std::setfill('0') << m << ':' << std::setw(2)
+        << sec;
+  }
+  return oss.str();
+}
+
+void Clock::setTime(float seconds) {
+  m_text.setString(formatTime(seconds));
+}
+
+void Clock::render(sf::RenderWindow& window) {
+  window.draw(m_box);
+  window.draw(m_text);
+}
+
+}  // namespace lilia::view
+

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -20,6 +20,8 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
       m_move_list(),
       m_top_player(),
       m_bottom_player(),
+      m_top_clock(),
+      m_bottom_clock(),
       m_modal(),
       m_particles() {
   // cursors
@@ -51,6 +53,10 @@ GameView::GameView(sf::RenderWindow &window, bool topIsBot, bool bottomIsBot)
   m_bottom_player.setPlayerColor(core::Color::White);
   m_black_player = &m_top_player;
   m_white_player = &m_bottom_player;
+  m_top_clock.setPlayerColor(core::Color::Black);
+  m_bottom_clock.setPlayerColor(core::Color::White);
+  m_black_clock = &m_top_clock;
+  m_white_clock = &m_bottom_clock;
 
   // board orientation
   m_board_view.setFlipped(bottomIsBot && !topIsBot);
@@ -94,6 +100,8 @@ void GameView::render() {
   m_piece_manager.renderPieces(m_window, m_chess_animator);
   m_highlight_manager.renderAttack(m_window);
   m_chess_animator.render(m_window);
+  m_top_clock.render(m_window);
+  m_bottom_clock.render(m_window);
 
   // right stack
   m_move_list.render(m_window);
@@ -258,6 +266,8 @@ void GameView::toggleBoardOrientation() {
   m_board_view.toggleFlipped();
   std::swap(m_top_player, m_bottom_player);
   std::swap(m_white_player, m_black_player);
+  std::swap(m_top_clock, m_bottom_clock);
+  std::swap(m_white_clock, m_black_clock);
   layout(m_window.getSize().x, m_window.getSize().y);
 }
 
@@ -275,6 +285,11 @@ void GameView::resetEvalBar() { m_eval_bar.reset(); }
 
 void GameView::setEvalResult(const std::string &result) {
   m_eval_bar.setResult(result);
+}
+
+void GameView::updateClock(core::Color color, float seconds) {
+  Clock &clk = (color == core::Color::White) ? *m_white_clock : *m_black_clock;
+  clk.setTime(seconds);
 }
 
 // ---------- Pieces / Highlights ----------
@@ -407,6 +422,11 @@ void GameView::layout(unsigned int width, unsigned int height) {
   m_bottom_player.setPositionClamped(
       {boardLeft + 5.f, boardTop + static_cast<float>(constant::WINDOW_PX_SIZE) + 15.f},
       m_window.getSize());
+
+  float clockX = boardLeft + static_cast<float>(constant::WINDOW_PX_SIZE) - Clock::WIDTH;
+  m_top_clock.setPosition({clockX, boardTop - Clock::HEIGHT - 5.f});
+  m_bottom_clock.setPosition(
+      {clockX, boardTop + static_cast<float>(constant::WINDOW_PX_SIZE) + 5.f});
 
   // keep modal centered on window/board changes
   m_modal.onResize(m_window.getSize(), m_board_view.getPosition());


### PR DESCRIPTION
## Summary
- Add `TimeController` class to manage per-side clocks with increment and timeout detection
- Introduce `Clock` UI component and integrate into `GameView`
- Extend game controller and start flow to handle clocks, increments, and timeout game results

## Testing
- `cmake -S . -B build` *(fails: Could NOT find VORBIS / FLAC / X11 libraries earlier; after installing dependencies, final build failed with missing X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f7f76494832985445554929409d7