### PR TITLE
Enable FEN clipboard support

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <string>
 #include <iostream>
+#include <SFML/Window/Clipboard.hpp>
 
 #include "lilia/controller/bot_player.hpp"
 #include "lilia/controller/game_manager.hpp"
@@ -236,7 +237,9 @@ void GameController::handleEvent(const sf::Event &event) {
       m_next_action = NextAction::Rematch;
       return;
     case view::MoveListView::Option::ShowFen:
-      std::cout << "FEN: " << m_fen_history[m_fen_index] << std::endl;
+      sf::Clipboard::setString(m_fen_history[m_fen_index]);
+      std::cout << "FEN copied to clipboard: " << m_fen_history[m_fen_index]
+                << std::endl;
       return;
     default:
       break;

--- a/src/lilia/view/start_screen.cpp
+++ b/src/lilia/view/start_screen.cpp
@@ -1,6 +1,7 @@
 #include "lilia/view/start_screen.hpp"
 
 #include <SFML/Graphics.hpp>
+#include <SFML/Window/Clipboard.hpp>
 #include <algorithm>  // for std::clamp, std::max
 #include <cctype>
 #include <cmath>
@@ -1079,7 +1080,14 @@ StartConfig StartScreen::run() {
           }
         }
         if (e.type == sf::Event::KeyPressed) {
-          if (e.key.code == sf::Keyboard::Escape) {
+          if (fenInputActive && (e.key.control || e.key.system) &&
+              e.key.code == sf::Keyboard::V) {
+            auto clip = sf::Clipboard::getString().toAnsiString();
+            clip.erase(std::remove(clip.begin(), clip.end(), '\n'), clip.end());
+            clip.erase(std::remove(clip.begin(), clip.end(), '\r'), clip.end());
+            m_fenString = clip;
+            m_fenInputText.setString(m_fenString);
+          } else if (e.key.code == sf::Keyboard::Escape) {
             m_showFenPopup = false;
             fenInputActive = false;
           } else if (e.key.code == sf::Keyboard::Enter) {


### PR DESCRIPTION
## Summary
- Support clipboard pasting into the FEN input box on the start screen
- Copy current FEN from game view to the system clipboard

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: undefined reference to XOpenDisplay, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5191cce288329a7a4fa0643d88bd6