### PR TITLE
Fix move list scroll clipping

### DIFF
--- a/src/lilia/view/move_list_view.cpp
+++ b/src/lilia/view/move_list_view.cpp
@@ -464,6 +464,12 @@ void MoveListView::render(sf::RenderWindow& window) const {
   fenTxt.setPosition(snapf(textX), snapf(kHeaderH + (kFenH - fb.height) / 2.f - fb.top - 2.f));
   window.draw(fenTxt);
 
+  // Clip scrolling content to the list area
+  sf::View listView(sf::FloatRect(0.f, topY, static_cast<float>(m_width),
+                                  listH - topY));
+  listView.setViewport(view.getViewport());
+  window.setView(listView);
+
   // --- Alternating rows + selection highlight ---
   const std::size_t totalLines = m_lines.size() + (m_result.empty() ? 0 : 1);
   const float visibleTop = topY;
@@ -562,6 +568,8 @@ void MoveListView::render(sf::RenderWindow& window) const {
       window.draw(r);
     }
   }
+
+  window.setView(view);
 
   // --- Footer / beveled controls ---
   sf::RectangleShape optionBG({static_cast<float>(m_width), m_option_height});


### PR DESCRIPTION
## Summary
- Ensure MoveListView scrollable content is clipped to its bounds by drawing within a dedicated view

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build` *(fail: undefined references to X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b52896465483299c30ed8563165424