### PR TITLE
Stop clock after game over and track time history

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -36,6 +36,12 @@ struct MoveView {
   int evalCp{};
 };
 
+struct TimeView {
+  float white;
+  float black;
+  core::Color active;
+};
+
 class GameController {
 public:
   explicit GameController(view::GameView &gView, model::ChessGame &game);
@@ -147,6 +153,7 @@ private:
   std::vector<int> m_eval_history;
   std::size_t m_fen_index{0};
   std::vector<MoveView> m_move_history;
+  std::vector<TimeView> m_time_history;
   NextAction m_next_action{NextAction::None};
 };
 

--- a/include/lilia/controller/time_controller.hpp
+++ b/include/lilia/controller/time_controller.hpp
@@ -13,6 +13,8 @@ class TimeController {
   void onMove(core::Color mover);
   void update(float dt);
 
+  void stop();
+
   [[nodiscard]] float getTime(core::Color color) const;
   [[nodiscard]] std::optional<core::Color> getFlagged() const;
   [[nodiscard]] std::optional<core::Color> getActive() const;

--- a/src/lilia/controller/time_controller.cpp
+++ b/src/lilia/controller/time_controller.cpp
@@ -34,6 +34,10 @@ void TimeController::update(float dt) {
   }
 }
 
+void TimeController::stop() {
+  m_running = false;
+}
+
 float TimeController::getTime(core::Color color) const {
   return (color == core::Color::White) ? m_white_time : m_black_time;
 }


### PR DESCRIPTION
## Summary
- Halt timers at game end and disable active clock indicator
- Snapshot both clocks after each move and restore them when browsing the move list

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e676af6c8329b7b21fe6589cb6bf