### PR TITLE
Fix premove rendering and chaining

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -111,6 +111,7 @@ private:
   [[nodiscard]] bool isPseudoLegalPremove(core::Square from, core::Square to) const;
   [[nodiscard]] model::Position getPositionAfterPremoves() const;
   [[nodiscard]] model::bb::Piece getPieceConsideringPremoves(core::Square sq) const;
+  [[nodiscard]] core::Square getFrontPremoveDestination() const;
   [[nodiscard]] bool hasVirtualPiece(core::Square sq) const;
 
   void movePieceAndClear(const model::Move &move, bool isPlayerMove,

--- a/include/lilia/view/piece_manager.hpp
+++ b/include/lilia/view/piece_manager.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "../controller/mousepos.hpp"
 #include "board_view.hpp"
@@ -49,6 +50,8 @@ class PieceManager {
   std::unordered_map<core::Square, Piece> m_pieces;
   // Pieces rendered for premove visualization without affecting board state
   std::unordered_map<core::Square, Piece> m_premove_pieces;
+  // Squares hidden from the main piece map during premove preview
+  std::unordered_set<core::Square> m_hidden_squares;
 };
 
 }  // namespace lilia::view

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -535,7 +535,8 @@ void GameController::enqueuePremove(core::Square from, core::Square to) {
   m_premove_queue.push_back(pm);
   if (!m_premove_queue.empty()) {
     const auto &front = m_premove_queue.front();
-    m_game_view.showPremovePiece(front.from, front.to);
+    core::Square dest = getFrontPremoveDestination();
+    m_game_view.showPremovePiece(front.from, dest);
   }
 }
 
@@ -655,7 +656,8 @@ void GameController::movePieceAndClear(const model::Move &move, bool isPlayerMov
     }
     if (!m_premove_queue.empty()) {
       const auto &front = m_premove_queue.front();
-      m_game_view.showPremovePiece(front.from, front.to);
+      core::Square dest = getFrontPremoveDestination();
+      m_game_view.showPremovePiece(front.from, dest);
     } else {
       m_game_view.clearPremovePieces();
     }
@@ -953,6 +955,18 @@ model::bb::Piece GameController::getPieceConsideringPremoves(core::Square sq) co
   model::Position pos = getPositionAfterPremoves();
   if (auto virt = pos.getBoard().getPiece(sq)) return *virt;
   return pc;
+}
+
+core::Square GameController::getFrontPremoveDestination() const {
+  if (m_premove_queue.empty()) return core::NO_SQUARE;
+  core::Square dest = m_premove_queue.front().to;
+  for (size_t i = 1; i < m_premove_queue.size(); ++i) {
+    if (m_premove_queue[i].from == dest)
+      dest = m_premove_queue[i].to;
+    else
+      break;
+  }
+  return dest;
 }
 
 bool GameController::hasVirtualPiece(core::Square sq) const {

--- a/src/lilia/view/piece_manager.cpp
+++ b/src/lilia/view/piece_manager.cpp
@@ -154,6 +154,7 @@ void PieceManager::renderPieces(sf::RenderWindow& window,
   for (auto& pair : m_pieces) {
     const auto& pos = pair.first;
     auto& piece = pair.second;
+    if (m_hidden_squares.count(pos) > 0) continue;
     if (!chessAnimRef.isAnimating(piece.getId())) {
       piece.setPosition(createPiecePositon(pos));
       piece.draw(window);
@@ -166,6 +167,7 @@ void PieceManager::renderPieces(sf::RenderWindow& window,
 }
 
 void PieceManager::renderPiece(core::Square pos, sf::RenderWindow& window) {
+  if (m_hidden_squares.count(pos) > 0) return;
   auto it = m_pieces.find(pos);
   if (it != m_pieces.end()) {
     it->second.draw(window);
@@ -179,8 +181,13 @@ void PieceManager::setPremovePiece(core::Square from, core::Square to) {
   ghost.setPosition(createPiecePositon(to));
   m_premove_pieces.clear();
   m_premove_pieces[to] = std::move(ghost);
+  m_hidden_squares.clear();
+  m_hidden_squares.insert(from);
 }
 
-void PieceManager::clearPremovePieces() { m_premove_pieces.clear(); }
+void PieceManager::clearPremovePieces() {
+  m_premove_pieces.clear();
+  m_hidden_squares.clear();
+}
 
 }  // namespace lilia::view


### PR DESCRIPTION
## Summary
- Hide original piece while previewing premove to prevent doubled pieces
- Compute final premove destination so chained premoves display correctly

## Testing
- `cmake -S .. -B .`
- `cmake --build . --target lilia_engine -j 2`


------
https://chatgpt.com/codex/tasks/task_e_68b60ad48d2883298e5e6d88c68f80df