### PR TITLE
Enforce strict button-only modal closure

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -61,6 +61,7 @@ class GameView {
   [[nodiscard]] bool isGameOverPopupOpen() const;
   [[nodiscard]] bool isOnNewBot(core::MousePos mousePos) const;
   [[nodiscard]] bool isOnRematch(core::MousePos mousePos) const;
+  [[nodiscard]] bool isOnModalClose(core::MousePos mousePos) const;
 
   [[nodiscard]] core::Square mousePosToSquare(core::MousePos mousePos) const;
   [[nodiscard]] core::MousePos clampPosToBoard(core::MousePos mousePos,

--- a/include/lilia/view/modal_view.hpp
+++ b/include/lilia/view/modal_view.hpp
@@ -36,6 +36,7 @@ class ModalView {
   bool hitResignNo(sf::Vector2f p) const;
   bool hitNewBot(sf::Vector2f p) const;
   bool hitRematch(sf::Vector2f p) const;
+  bool hitClose(sf::Vector2f p) const;
 
  private:
   // theme (kept local to avoid touching your constants)
@@ -53,8 +54,6 @@ class ModalView {
   sf::RectangleShape m_btnClose;
   sf::Text m_lblClose;
   sf::FloatRect m_hitClose;
-
-  bool hitClose(sf::Vector2f p) const;
 
   // state
   bool m_openResign = false;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -197,15 +197,21 @@ void GameController::handleEvent(const sf::Event &event) {
       if (m_game_view.isResignPopupOpen()) {
         if (m_game_view.isOnResignYes(mp)) {
           resign();
+          m_game_view.hideResignPopup();
+        } else if (m_game_view.isOnResignNo(mp) ||
+                   m_game_view.isOnModalClose(mp)) {
+          m_game_view.hideResignPopup();
         }
-        m_game_view.hideResignPopup();
       } else if (m_game_view.isGameOverPopupOpen()) {
         if (m_game_view.isOnNewBot(mp)) {
           m_next_action = NextAction::NewBot;
+          m_game_view.hideGameOverPopup();
         } else if (m_game_view.isOnRematch(mp)) {
           m_next_action = NextAction::Rematch;
+          m_game_view.hideGameOverPopup();
+        } else if (m_game_view.isOnModalClose(mp)) {
+          m_game_view.hideGameOverPopup();
         }
-        m_game_view.hideGameOverPopup();
       }
     }
     return;

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -243,6 +243,10 @@ bool GameView::isOnRematch(core::MousePos mousePos) const {
   return m_modal.hitRematch({static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
 }
 
+bool GameView::isOnModalClose(core::MousePos mousePos) const {
+  return m_modal.hitClose({static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
+}
+
 /* ---------- Input helpers ---------- */
 core::Square GameView::mousePosToSquare(core::MousePos mousePos) const {
   return m_board_view.mousePosToSquare(mousePos);


### PR DESCRIPTION
## Summary
- Expose modal close hit-test in `ModalView` and wire up `GameView` helper.
- Update game controller to only dismiss resign and game-over dialogs when clicking their buttons or close icon.

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b63672088c83298441225bd535e47e