### PR TITLE
Fix premove ghost handling and preserve piece identity

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -46,6 +46,8 @@ struct Premove {
   core::Square to;
   core::PieceType capturedType;
   core::Color capturedColor;
+  core::PieceType moverType;
+  core::Color moverColor;
 };
 
 struct TimeView {

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -102,7 +102,8 @@ class GameView {
   void clearAttackHighlights();
 
   // Preview helpers for premoves
-  void showPremovePiece(core::Square from, core::Square to);
+  void showPremovePiece(core::Square from, core::Square to,
+                        core::PieceType type, core::Color color);
   void clearPremovePieces(bool restore = true);
 
   void warningKingSquareAnim(core::Square ksq);

--- a/include/lilia/view/piece_manager.hpp
+++ b/include/lilia/view/piece_manager.hpp
@@ -40,7 +40,8 @@ class PieceManager {
   void renderPiece(core::Square pos, sf::RenderWindow& window);
 
   // Visual-only helpers for premove previews
-  void setPremovePiece(core::Square from, core::Square to);
+  void setPremovePiece(core::Square from, core::Square to,
+                       core::PieceType type, core::Color color);
   void clearPremovePieces(bool restore = true);
   void consumePremoveGhost(core::Square from, core::Square to);
 

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -421,8 +421,9 @@ void GameView::clearAttackHighlights() {
   m_highlight_manager.clearAttackHighlights();
 }
 
-void GameView::showPremovePiece(core::Square from, core::Square to) {
-  m_piece_manager.setPremovePiece(from, to);
+void GameView::showPremovePiece(core::Square from, core::Square to,
+                                core::PieceType type, core::Color color) {
+  m_piece_manager.setPremovePiece(from, to, type, color);
 }
 
 void GameView::clearPremovePieces(bool restore) {

--- a/src/lilia/view/piece_manager.cpp
+++ b/src/lilia/view/piece_manager.cpp
@@ -276,7 +276,8 @@ void PieceManager::renderPiece(core::Square pos, sf::RenderWindow &window) {
 }
 
 /* -------------------- Premove (ghost pieces) -------------------- */
-void PieceManager::setPremovePiece(core::Square from, core::Square to) {
+void PieceManager::setPremovePiece(core::Square from, core::Square to,
+                                   core::PieceType type, core::Color color) {
   // If the piece was already a ghost (chained premove), move that ghost
   Piece ghost;
   auto existing = m_premove_pieces.find(from);
@@ -287,9 +288,20 @@ void PieceManager::setPremovePiece(core::Square from, core::Square to) {
     m_hidden_squares.erase(from);
   } else {
     auto it = m_pieces.find(from);
-    if (it == m_pieces.end())
-      return;
-    ghost = it->second; // copy to preserve original
+    if (it != m_pieces.end() && it->second.getType() == type &&
+        it->second.getColor() == color) {
+      ghost = it->second; // copy to preserve original
+    } else {
+      std::uint8_t numTypes = 6;
+      std::string filename =
+          constant::ASSET_PIECES_FILE_PATH + "/piece_" +
+          std::to_string(static_cast<std::uint8_t>(type) +
+                         numTypes * static_cast<std::uint8_t>(color)) +
+          ".png";
+      const sf::Texture &texture = TextureTable::getInstance().get(filename);
+      ghost = Piece(color, type, texture);
+      ghost.setScale(constant::ASSET_PIECE_SCALE, constant::ASSET_PIECE_SCALE);
+    }
     m_hidden_squares.insert(from);
   }
 


### PR DESCRIPTION
## Summary
- Preserve original premove piece type/color to avoid captured piece overriding it
- Rebuild premove ghosts after auto-executed moves so only ghosts are visible until completion
- Ensure premove simulation stops if source piece no longer matches queued data

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: missing X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b64667a86c83298848261ff13c6c7a