### PR TITLE
fix: prevent ghost piece when premove queue full

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -109,7 +109,8 @@ private:
   void hoverSquare(core::Square sq);
   void dehoverSquare();
   void clearPremove();
-  void enqueuePremove(core::Square from, core::Square to);
+  /// Queue a premove; returns true if the premove was accepted.
+  [[nodiscard]] bool enqueuePremove(core::Square from, core::Square to);
   void updatePremovePreviews();
   [[nodiscard]] bool isPseudoLegalPremove(core::Square from, core::Square to) const;
   [[nodiscard]] model::Position getPositionAfterPremoves() const;


### PR DESCRIPTION
## Summary
- track premove enqueues with a return value
- reset dragging piece when a premove isn't accepted

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b68055ec7483298b8e548a3a6018e5