### PR TITLE
Refresh attack highlights when turn changes

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -568,6 +568,19 @@ void GameController::update(float dt) {
       // (Do NOT clear flags or the queue here.)
     }
   }
+
+  // If a piece is being held or selected while turns switch, ensure the
+  // attack highlights reflect the current player to move instead of lingering
+  // premove previews.
+  core::Square activeSq = core::NO_SQUARE;
+  if (m_dragging && isValid(m_drag_from)) {
+    activeSq = m_drag_from;
+  } else if (isValid(m_selected_sq)) {
+    activeSq = m_selected_sq;
+  }
+  if (isValid(activeSq) && isHumanPiece(activeSq)) {
+    showAttacks(getAttackSquares(activeSq));
+  }
 }
 
 /* -------------------- Highlights -------------------- */


### PR DESCRIPTION
## Summary
- ensure attack highlights are recalculated when a held or selected piece becomes the side to move, clearing premove colors

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_engine`


------
https://chatgpt.com/codex/tasks/task_e_68b6b9c67e8083298e996705689d7baf