### PR TITLE
Fix premove promotion handling

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -109,7 +109,7 @@ private:
   void hoverSquare(core::Square sq);
   void dehoverSquare();
   void clearPremove();
-  void enqueuePremove(core::Square from, core::Square to);
+  bool enqueuePremove(core::Square from, core::Square to);
   void updatePremovePreviews();
   [[nodiscard]] bool isPseudoLegalPremove(core::Square from, core::Square to) const;
   [[nodiscard]] model::Position getPositionAfterPremoves() const;
@@ -156,6 +156,13 @@ private:
 
   std::deque<Premove> m_premove_queue;
   bool m_premove_suspended = false; ///< Premove visuals hidden while browsing history
+  // Temporary info while waiting for a premove promotion selection
+  bool m_pending_premove_promotion = false;
+  core::Square m_ppromo_from = core::NO_SQUARE;
+  core::Square m_ppromo_to = core::NO_SQUARE;
+  core::PieceType m_ppromo_captured_type = core::PieceType::None;
+  core::Color m_ppromo_captured_color = core::Color::White;
+  core::Color m_ppromo_mover_color = core::Color::White;
   core::Square m_pending_from = core::NO_SQUARE;
   core::Square m_pending_to = core::NO_SQUARE;
   core::PieceType m_pending_capture_type = core::PieceType::None;


### PR DESCRIPTION
## Summary
- show promotion selection when queuing a premove that reaches the last rank
- track promotion choices for premoves and update ghost pieces accordingly
- cancel premove if promotion dialog dismissed without a selection

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_engine -j2`
- `cmake --build build --target lilia_app -j2` *(fails: undefined references to X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c18f10f4832990fc0abd62d64aa6