### PR TITLE
Render dragged piece above pieces and ghosts

### DIFF
--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -71,6 +71,9 @@ class GameView {
   void movePiece(core::Square from, core::Square to,
                  core::PieceType promotion = core::PieceType::None);
 
+  // Track the piece currently being dragged so it can be rendered above others
+  void clearDraggingPiece();
+
   [[nodiscard]] sf::Vector2u getWindowSize() const;
   [[nodiscard]] Entity::Position getPieceSize(core::Square pos) const;
 
@@ -151,6 +154,9 @@ class GameView {
   HighlightManager m_highlight_manager;
   animation::ChessAnimator m_chess_animator;
   PromotionManager m_promotion_manager;
+
+  // Currently dragged piece (if any)
+  core::Square m_dragging_piece{core::NO_SQUARE};
 
   // cursors
   sf::Cursor m_cursor_default;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -347,6 +347,8 @@ void GameController::handleEvent(const sf::Event &event) {
     case sf::Event::MouseLeft:
       m_mouse_down = false;
       m_dragging = false;
+      m_drag_from = core::NO_SQUARE;
+      m_game_view.clearDraggingPiece();
       m_game_view.setDefaultCursor();
       break;
     default:
@@ -424,6 +426,7 @@ void GameController::onMouseReleased(core::MousePos pos) {
   if (m_dragging) {
     m_dragging = false;
     m_drag_from = core::NO_SQUARE;
+    m_game_view.clearDraggingPiece();
   }
   m_preview_active = false;
   m_prev_selected_before_preview = core::NO_SQUARE;

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -121,10 +121,14 @@ void GameView::render() {
   // Animations and ghosts: ensure promotion overlay stays on top
   if (isInPromotionSelection()) {
     m_piece_manager.renderPremoveGhosts(m_window, m_chess_animator);
+    if (m_dragging_piece != core::NO_SQUARE)
+      m_piece_manager.renderPiece(m_dragging_piece, m_window);
     m_chess_animator.render(m_window);
   } else {
     m_chess_animator.render(m_window);
     m_piece_manager.renderPremoveGhosts(m_window, m_chess_animator);
+    if (m_dragging_piece != core::NO_SQUARE)
+      m_piece_manager.renderPiece(m_dragging_piece, m_window);
   }
   if (m_show_clocks) {
     m_top_clock.render(m_window);
@@ -276,11 +280,14 @@ core::MousePos GameView::clampPosToBoard(core::MousePos mousePos,
 void GameView::setPieceToMouseScreenPos(core::Square pos, core::MousePos mousePos) {
   auto size = getPieceSize(pos);
   m_piece_manager.setPieceToScreenPos(pos, clampPosToBoard(mousePos, size));
+  m_dragging_piece = pos;
 }
 
 void GameView::setPieceToSquareScreenPos(core::Square from, core::Square to) {
   m_piece_manager.setPieceToSquareScreenPos(from, to);
 }
+
+void GameView::clearDraggingPiece() { m_dragging_piece = core::NO_SQUARE; }
 
 void GameView::movePiece(core::Square from, core::Square to, core::PieceType promotion) {
   // IMPORTANT: reveal the real piece by consuming the premove ghost first


### PR DESCRIPTION
## Summary
- Track which piece is being dragged and expose a clear method
- Re-render dragged piece on top of pieces and premove ghosts while keeping it below promotion overlays
- Clear drag state on mouse release or when focus is lost

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b6d85654488329bbb4e2e440b98f47