### PR TITLE
Optimize view and controller updates

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 #include <deque>
+#include <limits>
 
 // Forward declaration to avoid heavy SFML header
 namespace sf {
@@ -178,6 +179,7 @@ private:
   std::unique_ptr<GameManager> m_game_manager;
   std::unique_ptr<TimeController> m_time_controller;
   std::atomic<int> m_eval_cp{0};
+  int m_prev_eval{std::numeric_limits<int>::min()};
 
   std::vector<std::string> m_fen_history;
   std::vector<int> m_eval_history;

--- a/include/lilia/view/animation/animation_manager.hpp
+++ b/include/lilia/view/animation/animation_manager.hpp
@@ -29,6 +29,7 @@ class AnimationManager {
   void cancelAll();
 
   bool hasInAnyLayer(Entity::ID_type entityID) const;
+  [[nodiscard]] bool empty() const;
 
  private:
   std::unordered_map<Entity::ID_type, std::unique_ptr<IAnimation>> m_highlight_level_animations;

--- a/include/lilia/view/animation/chess_animator.hpp
+++ b/include/lilia/view/animation/chess_animator.hpp
@@ -29,6 +29,7 @@ class ChessAnimator {
   void cancelAll();
 
   [[nodiscard]] bool isAnimating(Entity::ID_type entityID) const;
+  [[nodiscard]] bool hasActiveAnimations() const;
   void updateAnimations(float dt);
   void render(sf::RenderWindow& window);
   void renderHighlightLevel(sf::RenderWindow& window);

--- a/include/lilia/view/clock.hpp
+++ b/include/lilia/view/clock.hpp
@@ -29,6 +29,7 @@ class Clock {
   sf::Text m_text;
   sf::Font m_font;
   bool m_active{false};
+  float m_last_seconds{-1.f};
   sf::CircleShape m_icon_circle;
   sf::RectangleShape m_icon_hand;
 };

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -36,6 +36,7 @@ class GameView {
   void update(float dt);
   void updateEval(int eval);
   void render();
+  [[nodiscard]] bool needsUpdate() const;
 
   void addMove(const std::string &move);
   void addResult(const std::string &result);

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -158,6 +158,7 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot, bool bla
   m_move_history.clear();
   m_game_view.selectMove(static_cast<std::size_t>(-1));
   m_eval_cp.store(m_eval_history[0]);
+  m_prev_eval = m_eval_history[0];
   m_game_view.updateEval(m_eval_history[0]);
   m_game_view.clearCapturedPieces();
 
@@ -439,9 +440,15 @@ void GameController::render() {
 }
 
 void GameController::update(float dt) {
-  // Always tick UI/animations/particles
-  m_game_view.update(dt);
-  m_game_view.updateEval(m_eval_cp.load());
+  // Tick view components only if something is active
+  if (m_game_view.needsUpdate()) {
+    m_game_view.update(dt);
+  }
+  int eval = m_eval_cp.load();
+  if (eval != m_prev_eval) {
+    m_prev_eval = eval;
+    m_game_view.updateEval(eval);
+  }
 
   if (m_chess_game.getResult() != core::GameResult::ONGOING) return;
 

--- a/src/lilia/view/animation/animation_manager.cpp
+++ b/src/lilia/view/animation/animation_manager.cpp
@@ -39,6 +39,10 @@ void AnimationManager::addOrReplace(Entity::ID_type entityID, std::unique_ptr<IA
          m_highlight_level_animations.find(entityID) != m_highlight_level_animations.end();
 }
 
+[[nodiscard]] bool AnimationManager::empty() const {
+  return m_animations.empty() && m_highlight_level_animations.empty();
+}
+
 void AnimationManager::declareHighlightLevel(Entity::ID_type entityID) {
   // Robust: egal in welchem Layer – stelle sicher, dass sie im Highlight-Layer liegt
   // 1) Wenn bereits im Highlight: nichts tun

--- a/src/lilia/view/animation/chess_animator.cpp
+++ b/src/lilia/view/animation/chess_animator.cpp
@@ -65,6 +65,10 @@ void ChessAnimator::cancelAll() {
 [[nodiscard]] bool ChessAnimator::isAnimating(Entity::ID_type entityID) const {
   return m_anim_manager.isAnimating(entityID);
 }
+
+[[nodiscard]] bool ChessAnimator::hasActiveAnimations() const {
+  return !m_anim_manager.empty();
+}
 void ChessAnimator::updateAnimations(float dt) {
   m_anim_manager.update(dt);
 }

--- a/src/lilia/view/clock.cpp
+++ b/src/lilia/view/clock.cpp
@@ -136,6 +136,10 @@ void Clock::setPosition(const sf::Vector2f& pos) {
 }
 
 void Clock::setTime(float seconds) {
+  if (std::fabs(seconds - m_last_seconds) < 1e-3f) {
+    return;
+  }
+  m_last_seconds = seconds;
   m_text.setString(formatTime(seconds));
 
   // ensure the text fits: grow width if needed (height stays the same)

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -92,12 +92,20 @@ void GameView::init(const std::string &fen) {
 }
 
 void GameView::update(float dt) {
-  m_chess_animator.updateAnimations(dt);
-  m_particles.update(dt);
+  if (m_chess_animator.hasActiveAnimations()) {
+    m_chess_animator.updateAnimations(dt);
+  }
+  if (!m_particles.empty()) {
+    m_particles.update(dt);
+  }
 }
 
 void GameView::updateEval(int eval) {
   m_eval_bar.update(eval);
+}
+
+bool GameView::needsUpdate() const {
+  return m_chess_animator.hasActiveAnimations() || !m_particles.empty();
 }
 
 // game_view.cpp


### PR DESCRIPTION
## Summary
- Skip expensive view updates when no animations or particles are active
- Cache clock and evaluation values to avoid redundant rendering work
- Expose animation-manager helpers for checking active animations

## Testing
- `cmake -S . -B build` *(passed)*
- `cmake --build build` *(failed: missing X11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e8339c6c8329ab692afc5cb984b0