### PR TITLE
feat: add right-click highlight and premove cancellation

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -98,6 +98,7 @@ private:
   void onMouseMove(core::MousePos pos);
   void onMousePressed(core::MousePos pos);
   void onMouseReleased(core::MousePos pos);
+  void onRightClick(core::MousePos pos);
   void onClick(core::MousePos mousePos);
 
   void onDrag(core::MousePos start, core::MousePos current);

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -97,6 +97,7 @@ class GameView {
   void highlightCaptureSquare(core::Square pos);
   void highlightHoverSquare(core::Square pos);
   void highlightPremoveSquare(core::Square pos);
+  void highlightRightClickSquare(core::Square pos);
   void clearHighlightSquare(core::Square pos);
   void clearHighlightHoverSquare(core::Square pos);
   void clearHighlightPremoveSquare(core::Square pos);
@@ -104,6 +105,7 @@ class GameView {
   void clearAllHighlights();
   void clearNonPremoveHighlights();
   void clearAttackHighlights();
+  void clearRightClickHighlights();
 
   // Preview helpers for premoves
   void showPremovePiece(core::Square from, core::Square to,

--- a/include/lilia/view/highlight_manager.hpp
+++ b/include/lilia/view/highlight_manager.hpp
@@ -16,6 +16,7 @@ class HighlightManager {
   void highlightCaptureSquare(core::Square pos);
   void highlightHoverSquare(core::Square pos);
   void highlightPremoveSquare(core::Square pos);
+  void highlightRightClickSquare(core::Square pos);
   void clearAllHighlights();
   void clearNonPremoveHighlights();
   void clearAttackHighlights();
@@ -23,11 +24,13 @@ class HighlightManager {
   void clearHighlightHoverSquare(core::Square pos);
   void clearHighlightPremoveSquare(core::Square pos);
   void clearPremoveHighlights();
+  void clearRightClickHighlights();
 
   void renderAttack(sf::RenderWindow& window);
   void renderHover(sf::RenderWindow& window);
   void renderSelect(sf::RenderWindow& window);
   void renderPremove(sf::RenderWindow& window);
+  void renderRightClick(sf::RenderWindow& window);
 
  private:
   void renderEntitiesToBoard(std::unordered_map<core::Square, Entity>& map,
@@ -39,6 +42,7 @@ class HighlightManager {
   std::unordered_map<core::Square, Entity> m_hl_select_squares;
   std::unordered_map<core::Square, Entity> m_hl_hover_squares;
   std::unordered_map<core::Square, Entity> m_hl_premove_squares;
+  std::unordered_map<core::Square, Entity> m_hl_rclick_squares;
 };
 
 }  // namespace lilia::view

--- a/include/lilia/view/render_constants.hpp
+++ b/include/lilia/view/render_constants.hpp
@@ -49,6 +49,7 @@ const std::string STR_TEXTURE_CAPTUREHLIGHT = "captureHighlight";
 const std::string STR_TEXTURE_HOVERHLIGHT = "hoverHighlight";
 const std::string STR_TEXTURE_PREMOVEHLIGHT = "premoveHighlight";
 const std::string STR_TEXTURE_WARNINGHLIGHT = "warningHighlight";
+const std::string STR_TEXTURE_RCLICKHLIGHT = "rightClickHighlight";
 
 const std::string STR_FILE_PATH_HAND_OPEN = "assets/icons/cursor_hand_open.png";
 const std::string STR_FILE_PATH_HAND_CLOSED = "assets/icons/cursor_hand_closed.png";

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -338,6 +338,8 @@ void GameController::handleEvent(const sf::Event &event) {
     case sf::Event::MouseButtonPressed:
       if (event.mouseButton.button == sf::Mouse::Left)
         onMousePressed(core::MousePos(event.mouseButton.x, event.mouseButton.y));
+      else if (event.mouseButton.button == sf::Mouse::Right)
+        onRightClick(core::MousePos(event.mouseButton.x, event.mouseButton.y));
       break;
     case sf::Event::MouseButtonReleased:
       if (event.mouseButton.button == sf::Mouse::Left)
@@ -431,6 +433,14 @@ void GameController::onMouseReleased(core::MousePos pos) {
   m_preview_active = false;
   m_prev_selected_before_preview = core::NO_SQUARE;
   onMouseMove(pos);
+}
+
+void GameController::onRightClick(core::MousePos pos) {
+  const core::Square sq = m_game_view.mousePosToSquare(pos);
+  if (!isValid(sq)) return;
+  const bool hasPiece = hasVirtualPiece(sq);
+  if (!hasPiece) clearPremove();
+  m_game_view.highlightRightClickSquare(sq);
 }
 
 /* -------------------- Main loop hooks -------------------- */

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -117,6 +117,7 @@ void GameView::render() {
   // REAL pieces below animations
   m_piece_manager.renderPieces(m_window, m_chess_animator);
   m_highlight_manager.renderAttack(m_window);
+  m_highlight_manager.renderRightClick(m_window);
 
   // Animations and ghosts: ensure promotion overlay stays on top
   if (isInPromotionSelection()) {
@@ -413,6 +414,9 @@ void GameView::highlightCaptureSquare(core::Square pos) {
 void GameView::highlightPremoveSquare(core::Square pos) {
   m_highlight_manager.highlightPremoveSquare(pos);
 }
+void GameView::highlightRightClickSquare(core::Square pos) {
+  m_highlight_manager.highlightRightClickSquare(pos);
+}
 
 void GameView::clearHighlightSquare(core::Square pos) {
   m_highlight_manager.clearHighlightSquare(pos);
@@ -434,6 +438,9 @@ void GameView::clearNonPremoveHighlights() {
 }
 void GameView::clearAttackHighlights() {
   m_highlight_manager.clearAttackHighlights();
+}
+void GameView::clearRightClickHighlights() {
+  m_highlight_manager.clearRightClickHighlights();
 }
 
 void GameView::showPremovePiece(core::Square from, core::Square to, core::PieceType promotion) {

--- a/src/lilia/view/highlight_manager.cpp
+++ b/src/lilia/view/highlight_manager.cpp
@@ -9,7 +9,9 @@ HighlightManager::HighlightManager(const BoardView& boardRef)
     : m_board_view_ref(boardRef),
       m_hl_attack_squares(),
       m_hl_select_squares(),
-      m_hl_hover_squares() {}
+      m_hl_hover_squares(),
+      m_hl_premove_squares(),
+      m_hl_rclick_squares() {}
 
 void HighlightManager::renderEntitiesToBoard(std::unordered_map<core::Square, Entity>& map,
                                              sf::RenderWindow& window) {
@@ -32,6 +34,9 @@ void HighlightManager::renderSelect(sf::RenderWindow& window) {
 }
 void HighlightManager::renderPremove(sf::RenderWindow& window) {
   renderEntitiesToBoard(m_hl_premove_squares, window);
+}
+void HighlightManager::renderRightClick(sf::RenderWindow& window) {
+  renderEntitiesToBoard(m_hl_rclick_squares, window);
 }
 
 void HighlightManager::highlightSquare(core::Square pos) {
@@ -57,16 +62,23 @@ void HighlightManager::highlightPremoveSquare(core::Square pos) {
   newPremove.setScale(constant::SQUARE_PX_SIZE, constant::SQUARE_PX_SIZE);
   m_hl_premove_squares[pos] = std::move(newPremove);
 }
+void HighlightManager::highlightRightClickSquare(core::Square pos) {
+  Entity newRC(TextureTable::getInstance().get(constant::STR_TEXTURE_RCLICKHLIGHT));
+  newRC.setScale(constant::SQUARE_PX_SIZE, constant::SQUARE_PX_SIZE);
+  m_hl_rclick_squares[pos] = std::move(newRC);
+}
 void HighlightManager::clearAllHighlights() {
   m_hl_select_squares.clear();
   m_hl_attack_squares.clear();
   m_hl_hover_squares.clear();
   m_hl_premove_squares.clear();
+  m_hl_rclick_squares.clear();
 }
 void HighlightManager::clearNonPremoveHighlights() {
   m_hl_select_squares.clear();
   m_hl_attack_squares.clear();
   m_hl_hover_squares.clear();
+  m_hl_rclick_squares.clear();
 }
 void HighlightManager::clearAttackHighlights() { m_hl_attack_squares.clear(); }
 void HighlightManager::clearHighlightSquare(core::Square pos) {
@@ -80,6 +92,9 @@ void HighlightManager::clearHighlightPremoveSquare(core::Square pos) {
 }
 void HighlightManager::clearPremoveHighlights() {
   m_hl_premove_squares.clear();
+}
+void HighlightManager::clearRightClickHighlights() {
+  m_hl_rclick_squares.clear();
 }
 
 }  // namespace lilia::view

--- a/src/lilia/view/texture_table.cpp
+++ b/src/lilia/view/texture_table.cpp
@@ -426,6 +426,8 @@ void TextureTable::preLoad() {
        sf::Color(180, 120, 255, 160));  // purple-ish premove highlight
   load(constant::STR_TEXTURE_WARNINGHLIGHT,
        sf::Color(255, 102, 102, 190));  // #FF6666, clear check alert
+  load(constant::STR_TEXTURE_RCLICKHLIGHT,
+       sf::Color(255, 80, 80, 170));  // red-ish right-click highlight
 
   m_textures[constant::STR_TEXTURE_ATTACKHLIGHT] =
       std::move(makeAttackDotTexture(constant::ATTACK_DOT_PX_SIZE));


### PR DESCRIPTION
## Summary
- add a right-click highlight with a red overlay
- allow right-clicking empty squares to clear the premove queue
- render right-click highlights above other highlight layers

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68b6e9e877b48329839348900a0b02cf