### PR TITLE
Fix stale right-click and premove highlights

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -386,6 +386,7 @@ void GameController::onMousePressed(core::MousePos pos) {
 
   if (!hasVirtualPiece(sq)) {
     m_game_view.setDefaultCursor();
+    m_game_view.clearRightClickHighlights();
     return;
   }
 
@@ -688,6 +689,11 @@ bool GameController::enqueuePremove(core::Square from, core::Square to) {
 
 void GameController::clearPremove() {
   if (!m_premove_queue.empty() || m_pending_premove_promotion) {
+    for (const auto &pm : m_premove_queue) {
+      m_game_view.clearHighlightSquare(pm.to);
+    }
+    if (m_pending_premove_promotion && m_ppromo_to != core::NO_SQUARE)
+      m_game_view.clearHighlightSquare(m_ppromo_to);
     m_premove_queue.clear();
     m_game_view.clearPremoveHighlights();
     m_game_view.clearPremovePieces(true);  // restore any stashed captures


### PR DESCRIPTION
## Summary
- Clear right-click highlights when clicking on empty board squares
- Remove lingering move highlights when canceling premoves

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68b6f05264448329bc01061ab40a27b2