### PR TITLE
Emit confetti only for human victories

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -144,6 +144,9 @@ private:
   InputManager m_input_manager;   ///< Handles raw input processing.
   view::sound::SoundManager m_sound_manager; ///< Handles sfx and music
 
+  bool m_white_is_bot{false};
+  bool m_black_is_bot{false};
+
   core::Square m_promotion_square = core::NO_SQUARE;
 
   bool m_dragging = false;

--- a/include/lilia/view/game_view.hpp
+++ b/include/lilia/view/game_view.hpp
@@ -56,7 +56,7 @@ class GameView {
   [[nodiscard]] bool isOnResignYes(core::MousePos mousePos) const;
   [[nodiscard]] bool isOnResignNo(core::MousePos mousePos) const;
 
-  void showGameOverPopup(const std::string &msg);
+  void showGameOverPopup(const std::string &msg, bool humanWinner);
   void hideGameOverPopup();
   [[nodiscard]] bool isGameOverPopupOpen() const;
   [[nodiscard]] bool isOnNewBot(core::MousePos mousePos) const;

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -129,6 +129,8 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot, bool bla
   m_game_view.setGameOver(false);
   m_game_view.init(fen);
   m_game_view.setBotMode(whiteIsBot || blackIsBot);
+  m_white_is_bot = whiteIsBot;
+  m_black_is_bot = blackIsBot;
   m_game_manager->startGame(fen, whiteIsBot, blackIsBot, whiteThinkTimeMs, whiteDepth,
                             blackThinkTimeMs, blackDepth);
 
@@ -1381,35 +1383,43 @@ void GameController::showGameOver(core::GameResult res, core::Color sideToMove) 
 
   m_sound_manager.playEffect(view::sound::Effect::GameEnds);
   std::string resultStr;
+  core::Color winner = (sideToMove == core::Color::White) ? core::Color::Black
+                                                          : core::Color::White;
+  bool humanWinner = (winner == core::Color::White && !m_white_is_bot) ||
+                     (winner == core::Color::Black && !m_black_is_bot);
   switch (res) {
     case core::GameResult::CHECKMATE:
       resultStr = (sideToMove == core::Color::White) ? "0-1" : "1-0";
-      m_game_view.showGameOverPopup(sideToMove == core::Color::White ? "Black won" : "White won");
+      m_game_view.showGameOverPopup(
+          sideToMove == core::Color::White ? "Black won" : "White won",
+          humanWinner);
       break;
     case core::GameResult::TIMEOUT:
       resultStr = (sideToMove == core::Color::White) ? "0-1" : "1-0";
-      m_game_view.showGameOverPopup(sideToMove == core::Color::White ? "Black wins on time"
-                                                                     : "White wins on time");
+      m_game_view.showGameOverPopup(
+          sideToMove == core::Color::White ? "Black wins on time"
+                                           : "White wins on time",
+          humanWinner);
       break;
     case core::GameResult::REPETITION:
       resultStr = "1/2-1/2";
-      m_game_view.showGameOverPopup("Draw by repetition");
+      m_game_view.showGameOverPopup("Draw by repetition", false);
       break;
     case core::GameResult::MOVERULE:
       resultStr = "1/2-1/2";
-      m_game_view.showGameOverPopup("Draw by 50 move rule");
+      m_game_view.showGameOverPopup("Draw by 50 move rule", false);
       break;
     case core::GameResult::STALEMATE:
       resultStr = "1/2-1/2";
-      m_game_view.showGameOverPopup("Stalemate");
+      m_game_view.showGameOverPopup("Stalemate", false);
       break;
     case core::GameResult::INSUFFICIENT:
       resultStr = "1/2-1/2";
-      m_game_view.showGameOverPopup("Insufficient material");
+      m_game_view.showGameOverPopup("Insufficient material", false);
       break;
     default:
       resultStr = "error";
-      m_game_view.showGameOverPopup("result is not correct");
+      m_game_view.showGameOverPopup("result is not correct", false);
       break;
   }
   m_game_view.addResult(resultStr);

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -239,10 +239,10 @@ bool GameView::isOnResignNo(core::MousePos mousePos) const {
   return m_modal.hitResignNo({static_cast<float>(mousePos.x), static_cast<float>(mousePos.y)});
 }
 
-void GameView::showGameOverPopup(const std::string &msg) {
+void GameView::showGameOverPopup(const std::string &msg, bool humanWinner) {
   auto center = m_board_view.getPosition();
   m_modal.showGameOver(msg, {center.x, center.y});
-  if (msg.find("won") != std::string::npos) {
+  if (humanWinner && msg.find("won") != std::string::npos) {
     m_particles.emitConfetti(center, static_cast<float>(constant::WINDOW_PX_SIZE), 200);
   }
 }


### PR DESCRIPTION
## Summary
- Track which sides are bots to determine human winners
- Only emit confetti on game over when a human wins

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68b703b31020832983767ee818d66ef3