### PR TITLE
Fix disappearing pieces when cancelling premove chains

### DIFF
--- a/src/lilia/view/piece_manager.cpp
+++ b/src/lilia/view/piece_manager.cpp
@@ -295,14 +295,8 @@ void PieceManager::setPremovePiece(core::Square from, core::Square to, core::Pie
       m_premove_origin.erase(itO);
     }
 
-    // If this square held a stashed capture from an earlier step,
-    // drop it now so the captured piece doesn't get resurrected and
-    // accidentally participate in later premoves. Once the ghost
-    // moves on, the replacement is final.
-    if (auto bak = m_captured_backup.find(from); bak != m_captured_backup.end()) {
-      m_captured_backup.erase(bak);
-    }
-
+    // If this square held a stashed capture from an earlier step, keep the
+    // backup so cancelling the premove restores everything.
     if (promotion != core::PieceType::None) {
       ghost = makeGhost(promotion, ghost.getColor());
     }


### PR DESCRIPTION
## Summary
- Keep backups of pieces captured during premove previews so cancelling the queue restores them

## Testing
- `cmake -S . -B build` *(fails: could NOT find FLAC/others? Wait now succeeded? yes last run succeeded)*
- `cmake --build build` *(fails: undefined references to X11 functions)*

------
https://chatgpt.com/codex/tasks/task_e_68b71948ded08329b435405adf366bf9