### PR TITLE
docs: refresh README with project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,37 @@
 # Lilia Chess Engine
 
-Lilia is a Windows-only chess project written in modern **C++20**. It is split into the SFML-based **LiliaApp** graphical client and the standalone **liliaengine** core, which is fully UCI compatible and can be used with any UCI front-end.
+Lilia is a Windows‑focused chess sandbox written in modern **C++20**. The repository hosts both the SFML‑based **LiliaApp** GUI and the standalone **liliaengine** core. The engine speaks [UCI](https://en.wikipedia.org/wiki/Universal_Chess_Interface) and can be plugged into any UCI front‑end.
 
-## Design Highlights
+👉 **Get prebuilt binaries** from the [Releases tab](https://github.com/JustAnoAim/Lilia/releases) to try the latest version of the engine and GUI.
+
+## Project Idea & Design
+Lilia is first and foremost a playground to experiment with chess‑engine ideas. The code base is deliberately modular so that algorithms can be swapped in and out with minimal friction.
+
 - Clear separation between *engine* and *app* modules.
 - Modular MVC layout (`model`, `engine`, `uci` / `view`, `controller`, `app`).
-- Bitboard-based board representation for fast move generation.
+- Bitboard board representation for fast move generation.
 - Multithreaded search designed for maintainability and experimentation.
 
-## Algorithms & Techniques
-- Negamax search with alpha-beta pruning.
-- Iterative deepening with aspiration windows.
-- Quiescence search to reduce horizon effects.
-- Transposition table (TT4) using Zobrist hashing.
-- Move ordering heuristics (killer moves, history heuristic, null-move pruning).
+## Search Algorithms
+The search is a classic negamax with alpha‑beta pruning augmented by many heuristics and pruning ideas from modern engines:
+
+- Iterative deepening with aspiration windows and principal variation search.
+- Late move reductions with a pre‑tuned reduction table.
+- Null‑move pruning, razoring and multiple futility pruning stages.
+- SEE pruning, ProbCut and light check extensions.
+- Rich move ordering: transposition table, killer moves, quiet/capture histories, counter‑moves and history pruning.
+
+## Evaluation
+The handcrafted evaluator mixes material, mobility and many structural features:
+
+- Piece‑square tables and mobility profiles for each piece.
+- Pawn structure: isolated, doubled and backward pawns, phalanxes, candidates and connected or passed pawns.
+- King safety: pawn shields, king rings and storm/shelter tables.
+- Piece‑specific motifs such as bishop pair, outposts, rooks on open files or behind passers, connected rooks and more.
+- Threat detection, space and material imbalance terms.
+
+## Transposition Table
+The engine currently uses **TT5**, a compact 16‑byte entry table with two‑stage key verification and generation‑based aging for fast lookups.
 
 ## Project Structure
 ```
@@ -30,24 +48,6 @@ Lilia is a Windows-only chess project written in modern **C++20**. It is split i
     ├── uci/       # UCI protocol implementation
     └── view/      # SFML-based rendering
 ```
-
-## Building (Windows 64-bit)
-1. **Prerequisites**
-   - [CMake](https://cmake.org/)
-   - A C++20 compiler (tested with MinGW-w64)
-   - Git (for fetching SFML via `FetchContent`)
-
-2. **Configure and build**
-
-   ```bash
-   cmake -S . -B build
-   cmake --build build --config Release
-   ```
-   The Release binaries will be placed in `build/bin/Release/`.
-
-3. **Run**
-   - `build/bin/Release/lilia_engine.exe` – console UCI engine
-   - `build/bin/Release/lilia_app.exe` – SFML GUI
 
 ## Using the Engine
 - `liliaengine` speaks the [UCI protocol](https://en.wikipedia.org/wiki/Universal_Chess_Interface) and can be plugged into any UCI-compatible GUI.
@@ -74,3 +74,8 @@ Design patterns used include:
 - **Observer-like callbacks** from `GameManager` to notify other components of state changes.
 - **Factory** to generate fresh evaluator instances for each search thread (`EvalFactory`).
 - **Facade** through `GameView`, which offers a simplified interface to the rendering subsystem.
+
+## Future Work
+- Integrate an NNUE evaluation backend.
+- Continue exploring new pruning techniques and search ideas.
+- Improve cross-platform support.


### PR DESCRIPTION
## Summary
- highlight Lilia as a sandbox project with modular engine and GUI
- document search heuristics, evaluation features and TT5 transposition table
- remove obsolete Windows build section from README
- add release link and future work section

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b7567db7408329b6b1e17dfebfed13