### PR TITLE
Optimize controller move caching and attack rendering

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -26,6 +26,7 @@ namespace lilia::model {
 class ChessGame;
 struct Move;
 class Position;
+class MoveGenerator;
 namespace bb {
 struct Piece;
 }
@@ -119,9 +120,8 @@ private:
 
   void snapAndReturn(core::Square sq, core::MousePos cur);
 
-  [[nodiscard]] std::vector<core::Square>
-  getAttackSquares(core::Square pieceSQ) const;
-  void showAttacks(std::vector<core::Square> att);
+  [[nodiscard]] const std::vector<core::Square> &getAttackSquares(core::Square pieceSQ) const;
+  void showAttacks(const std::vector<core::Square> &att);
   [[nodiscard]] bool tryMove(core::Square a, core::Square b);
   [[nodiscard]] bool isPromotion(core::Square a, core::Square b);
   [[nodiscard]] bool isSameColor(core::Square a, core::Square b);
@@ -181,6 +181,14 @@ private:
   std::vector<MoveView> m_move_history;
   std::vector<TimeView> m_time_history;
   NextAction m_next_action{NextAction::None};
+
+  mutable model::MoveGenerator m_movegen;
+  mutable std::vector<model::Move> m_pseudo_buffer;
+  mutable std::vector<core::Square> m_attack_buffer;
+  mutable const std::vector<model::Move> *m_cached_moves{nullptr};
+
+  void invalidateLegalCache();
+  void ensureLegalCache() const;
 };
 
 } // namespace lilia::controller

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -104,16 +104,16 @@ void GameView::render() {
   m_highlight_manager.renderRightClick(m_window);
 
   // Animations and ghosts: ensure promotion overlay stays on top
-  if (isInPromotionSelection()) {
+  const bool inPromotion = isInPromotionSelection();
+  const bool draggingPiece = m_dragging_piece != core::NO_SQUARE;
+  if (inPromotion) {
     m_piece_manager.renderPremoveGhosts(m_window, m_chess_animator);
-    if (m_dragging_piece != core::NO_SQUARE)
-      m_piece_manager.renderPiece(m_dragging_piece, m_window);
+    if (draggingPiece) m_piece_manager.renderPiece(m_dragging_piece, m_window);
     m_chess_animator.render(m_window);
   } else {
     m_chess_animator.render(m_window);
     m_piece_manager.renderPremoveGhosts(m_window, m_chess_animator);
-    if (m_dragging_piece != core::NO_SQUARE)
-      m_piece_manager.renderPiece(m_dragging_piece, m_window);
+    if (draggingPiece) m_piece_manager.renderPiece(m_dragging_piece, m_window);
   }
   if (m_show_clocks) {
     m_top_clock.render(m_window);


### PR DESCRIPTION
## Summary
- preallocate controller history containers to limit reallocations during games
- cache promotion/dragging flags in `GameView::render` to avoid repeated checks
- reuse pre-reserved attack buffers and show attacks by reference
- cache legal moves and reuse move generator to minimize move generation calls

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68b86933c26c8329b941b094bc26b7dc