### PR TITLE
Highlight low time in clock and show milliseconds

### DIFF
--- a/include/lilia/view/clock.hpp
+++ b/include/lilia/view/clock.hpp
@@ -28,7 +28,11 @@ class Clock {
   sf::RectangleShape m_overlay;
   sf::Text m_text;
   sf::Font m_font;
+  // Remember the player's base theme/text color so low-time highlighting
+  // can temporarily override it without losing the original.
+  sf::Color m_text_base_color;
   bool m_active{false};
+  bool m_is_light_theme{false};
   sf::CircleShape m_icon_circle;
   sf::RectangleShape m_icon_hand;
 };


### PR DESCRIPTION
## Summary
- Extend Clock component to track base text color for theme preservation
- Display tenths of a second and highlight text red when time is 20s or less

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build` *(fails: Makefile: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9298452648329bbae515af3825c12