### PR TITLE
Improve right-click highlight layering

### DIFF
--- a/include/lilia/view/highlight_manager.hpp
+++ b/include/lilia/view/highlight_manager.hpp
@@ -36,7 +36,8 @@ class HighlightManager {
   void renderHover(sf::RenderWindow& window);
   void renderSelect(sf::RenderWindow& window);
   void renderPremove(sf::RenderWindow& window);
-  void renderRightClick(sf::RenderWindow& window);
+  void renderRightClickSquares(sf::RenderWindow& window);
+  void renderRightClickArrows(sf::RenderWindow& window);
 
  private:
   void renderEntitiesToBoard(std::unordered_map<core::Square, Entity>& map,

--- a/src/lilia/view/game_view.cpp
+++ b/src/lilia/view/game_view.cpp
@@ -99,11 +99,12 @@ void GameView::render() {
   m_highlight_manager.renderPremove(m_window);
   m_chess_animator.renderHighlightLevel(m_window);
   m_highlight_manager.renderHover(m_window);
+  m_highlight_manager.renderRightClickSquares(m_window);
 
   // REAL pieces below animations
-  m_highlight_manager.renderRightClick(m_window);
   m_piece_manager.renderPieces(m_window, m_chess_animator);
   m_highlight_manager.renderAttack(m_window);
+  m_highlight_manager.renderRightClickArrows(m_window);
 
   // Animations and ghosts: ensure promotion overlay stays on top
   const bool inPromotion = isInPromotionSelection();

--- a/src/lilia/view/highlight_manager.cpp
+++ b/src/lilia/view/highlight_manager.cpp
@@ -42,14 +42,16 @@ void HighlightManager::renderSelect(sf::RenderWindow& window) {
 void HighlightManager::renderPremove(sf::RenderWindow& window) {
   renderEntitiesToBoard(m_hl_premove_squares, window);
 }
-void HighlightManager::renderRightClick(sf::RenderWindow& window) {
+void HighlightManager::renderRightClickSquares(sf::RenderWindow& window) {
   renderEntitiesToBoard(m_hl_rclick_squares, window);
-
+}
+void HighlightManager::renderRightClickArrows(sf::RenderWindow& window) {
   const sf::Color col(255, 80, 80, 170);
   const float sqSize = static_cast<float>(constant::SQUARE_PX_SIZE);
   const float thickness = sqSize * 0.15f;
   const float headLength = sqSize * 0.45f;
   const float headWidth = sqSize * 0.45f;
+  const float edgeOffset = sqSize * 0.5f * 0.9f;
 
   auto drawSegment = [&](sf::Vector2f s, sf::Vector2f e, bool arrowHead) {
     sf::Vector2f diff = e - s;
@@ -96,10 +98,27 @@ void HighlightManager::renderRightClick(sf::RenderWindow& window) {
       core::Square cornerSq = static_cast<core::Square>(
           cornerFile + cornerRank * constant::BOARD_SIZE);
       sf::Vector2f corner = m_board_view_ref.getSquareScreenPos(cornerSq);
-      drawSegment(fromPos, corner, false);
+
+      int dx1 = cornerFile - fx;
+      int dy1 = cornerRank - fy;
+      sf::Vector2f start = fromPos;
+      start.x += (dx1 > 0 ? edgeOffset : dx1 < 0 ? -edgeOffset : 0.f);
+      start.y += (dy1 > 0 ? edgeOffset : dy1 < 0 ? -edgeOffset : 0.f);
+
+      drawSegment(start, corner, false);
       drawSegment(corner, toPos, true);
+      sf::CircleShape joint(thickness / 2.f);
+      joint.setOrigin(thickness / 2.f, thickness / 2.f);
+      joint.setFillColor(col);
+      joint.setPosition(corner);
+      window.draw(joint);
     } else {
-      drawSegment(fromPos, toPos, true);
+      sf::Vector2f start = fromPos;
+      int sgnX = (tx > fx) ? 1 : (tx < fx ? -1 : 0);
+      int sgnY = (ty > fy) ? 1 : (ty < fy ? -1 : 0);
+      start.x += sgnX * edgeOffset;
+      start.y += sgnY * edgeOffset;
+      drawSegment(start, toPos, true);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Draw right-click square highlights beneath pieces
- Render right-click arrows above attack highlights
- Start arrows near square edges and corners with smooth 90° turns

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: undefined references to X11 functions)*

------
https://chatgpt.com/codex/tasks/task_e_68ba07d4bae48329b3b5d4e5537e2269