### PR TITLE
Use configuration thread count for search threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ The engine currently uses **TT5**, a compact 16‑byte entry table with two‑st
 - `liliaengine` speaks the [UCI protocol](https://en.wikipedia.org/wiki/Universal_Chess_Interface) and can be plugged into any UCI-compatible GUI.
 - The engine can also be linked as a library; see `examples/main.cpp` for a minimal integration example.
 
+### Thread configuration
+Lock the search to a specific number of threads by setting `EngineConfig::threads` or via the UCI `Threads` option. The engine
+uses this value deterministically and does not resize the thread pool based on runtime hardware queries.
+
 ## Acknowledgements
 - Graphics, windowing and audio are provided by [SFML](https://www.sfml-dev.org/).
 - This setup is currently optimized for **Windows 64-bit** architecture.

--- a/include/lilia/engine/search.hpp
+++ b/include/lilia/engine/search.hpp
@@ -67,6 +67,7 @@ class Search {
   Search& operator=(Search&&) = delete;
 
   // Root (iterative deepening, parallel auf Root-Children)
+  // maxThreads <= 0 -> use cfg.threads for deterministic thread count
   int search_root_parallel(model::Position& pos, int depth, std::shared_ptr<std::atomic<bool>> stop,
                            int maxThreads = 0, std::uint64_t maxNodes = 0);
   void set_node_limit(std::shared_ptr<std::atomic<std::uint64_t>> shared, std::uint64_t limit) {

--- a/src/lilia/engine/engine.cpp
+++ b/src/lilia/engine/engine.cpp
@@ -6,6 +6,7 @@
 #include "lilia/engine/eval.hpp"  // <- Evaluator
 #include "lilia/engine/move_order.hpp"
 #include "lilia/engine/search.hpp"
+#include "lilia/engine/thread_pool.hpp"
 #include "lilia/model/core/magic.hpp"
 
 namespace lilia::engine {
@@ -28,6 +29,9 @@ struct Engine::Impl {
     } else {
       cfg.threads = std::clamp(cfg.threads, 1, logical);
     }
+
+    // Initialize thread pool once using the configured thread count
+    ThreadPool::instance(cfg.threads);
 
     eval = std::make_shared<Evaluator>();
     search = std::make_unique<Search>(tt, eval, cfg);

--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -11,7 +11,6 @@
 #include <limits>
 #include <memory>
 #include <mutex>
-#include <thread>
 #include <unordered_set>
 #include <vector>
 
@@ -839,11 +838,10 @@ int Search::search_root_parallel(model::Position& pos, int maxDepth,
     return 0;
   }
 
-  // Thread-Pool setup
-  auto& pool = ThreadPool::instance(maxThreads);
-  const int hw = (int)std::thread::hardware_concurrency();
-  const int threads = std::max(1, maxThreads > 0 ? maxThreads : (hw > 0 ? hw : 1));
-  pool.maybe_resize(threads);
+  // Thread-Pool setup (pool initialized at engine startup)
+  auto& pool = ThreadPool::instance();
+  const int threads =
+      std::max(1, maxThreads > 0 ? std::min(maxThreads, cfg.threads) : cfg.threads);
 
   // Aspiration seed
   int lastScoreGuess = 0;


### PR DESCRIPTION
## Summary
- Initialize the global thread pool once during engine startup using `EngineConfig::threads`
- Remove hardware queries from `search_root_parallel` and fall back to configured thread count
- Document how to lock the engine to a specific number of threads

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_68ba7739e16883299b9956c183943cbb