### PR TITLE
Use palette-based background gradient

### DIFF
--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -10,6 +10,7 @@
 #include "lilia/view/game_view.hpp"
 #include "lilia/view/start_screen.hpp"
 #include "lilia/view/texture_table.hpp"
+#include "lilia/view/render_constants.hpp"
 
 namespace lilia::app {
 
@@ -73,7 +74,8 @@ int App::run() {
           gameController.handleEvent(event);
         }
         gameController.update(deltaSeconds);
-        drawVerticalGradient(window, sf::Color{24, 29, 38}, sf::Color{16, 19, 26});
+        drawVerticalGradient(window, view::constant::COL_BG_TOP,
+                             view::constant::COL_BG_BOTTOM);
         gameController.render();
         window.display();
       }


### PR DESCRIPTION
## Summary
- Use color palette's COL_BG_TOP and COL_BG_BOTTOM for the game's background gradient so themes like Rose Noir and Chess.com affect the app window

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68ba8a5be1ac8329bd496d5066ee74b4