### PR TITLE
Open dropdowns on hover and highlight selections

### DIFF
--- a/include/lilia/view/start_screen.hpp
+++ b/include/lilia/view/start_screen.hpp
@@ -76,7 +76,9 @@ class StartScreen {
   sf::RectangleShape m_paletteButton;
   sf::Text m_paletteText;
   std::vector<PaletteOption> m_paletteOptions;
+  std::size_t m_paletteSelection{0};
   bool m_showPaletteList{false};
+  bool m_paletteListForceHide{false};
 
   // FEN popup UI
   bool m_showFenPopup{false};


### PR DESCRIPTION
## Summary
- Show color palette and bot lists on hover instead of click
- Track and highlight current selection in palette and bot lists

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: ‘uint64_t’ in namespace ‘std’ does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68babd819afc8329904bf75ee267a654