### PR TITLE
Layer copy icon square above

### DIFF
--- a/src/lilia/view/move_list_view.cpp
+++ b/src/lilia/view/move_list_view.cpp
@@ -242,11 +242,12 @@ void drawFenIcon(sf::RenderWindow& win, const sf::FloatRect& slot, bool hovered,
 
   // modern two-square copy icon
   sf::Color col = hovered ? constant::COL_ACCENT_HOVER : constant::COL_TEXT;
+  sf::Color fill = hovered ? constant::COL_HOVER_BG : constant::COL_SLOT_BASE;
   const float w = slot.width * 0.55f;
   const float h = slot.height * 0.55f;
   const float off = w * 0.25f;
 
-  const float bx = snapf(slot.left + (slot.width - w) * 0.5f + off);
+  const float bx = snapf(slot.left + (slot.width - w) * 0.5f - off);
   const float by = snapf(slot.top + (slot.height - h) * 0.5f - off);
   sf::RectangleShape back({w, h});
   back.setPosition(bx, by);
@@ -255,11 +256,11 @@ void drawFenIcon(sf::RenderWindow& win, const sf::FloatRect& slot, bool hovered,
   back.setOutlineColor(col);
   win.draw(back);
 
-  const float fx = snapf(slot.left + (slot.width - w) * 0.5f - off);
+  const float fx = snapf(slot.left + (slot.width - w) * 0.5f + off);
   const float fy = snapf(slot.top + (slot.height - h) * 0.5f + off);
   sf::RectangleShape front({w, h});
   front.setPosition(fx, fy);
-  front.setFillColor(sf::Color::Transparent);
+  front.setFillColor(fill);
   front.setOutlineThickness(2.f);
   front.setOutlineColor(col);
   win.draw(front);


### PR DESCRIPTION
## Summary
- Adjust copy icon squares to overlap, drawing the lower square atop the upper.
- Fill the topmost square with a theme-aware background color for proper layering.

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf27776a08329930152abcc86b009