### PR TITLE
Reset dragged piece when game ends

### DIFF
--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -1425,9 +1425,20 @@ bool GameController::isPseudoLegalPremove(core::Square from, core::Square to) co
 }
 
 void GameController::showGameOver(core::GameResult res, core::Color sideToMove) {
-  // Reset any dragging state and cursor
+  // Reset any dragging state so no piece remains floating when the game ends.
   m_mouse_down = false;
-  m_dragging = false;
+  m_input_manager.cancelDrag();
+
+  if (m_dragging) {
+    if (m_drag_from != core::NO_SQUARE) {
+      // Stop the placeholder animation and snap the piece back to its origin square.
+      m_game_view.endAnimation(m_drag_from);
+      m_game_view.setPieceToSquareScreenPos(m_drag_from, m_drag_from);
+    }
+    m_game_view.clearDraggingPiece();
+    m_dragging = false;
+    m_drag_from = core::NO_SQUARE;
+  }
   m_game_view.setDefaultCursor();
 
   // Ensure no premove state or visuals linger after the game ends


### PR DESCRIPTION
## Summary
- Ensure ongoing drags are cancelled on game over
- Snap the floating piece back to its origin square and clear placeholder animation

## Testing
- ⚠️ `cmake -S . -B build` *(missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR)*

------
https://chatgpt.com/codex/tasks/task_e_68bceb4901408329b6ac5bd5d9e7c180