### PR TITLE
Improve passer blocker evaluation by rank

### DIFF
--- a/include/lilia/engine/eval_shared.hpp
+++ b/include/lilia/engine/eval_shared.hpp
@@ -104,8 +104,8 @@ constexpr int ROOK_CUT_MIN_SEPARATION = 2;  // Mindestens 2 Linien Abstand = „
 constexpr int ROOK_CUT_BONUS = 14;
 
 // Stopper-Qualität (Wer blockiert Passer-Stopfeld?)
-constexpr int BLOCK_PASSER_STOP_KNIGHT = 6;  // gut
-constexpr int BLOCK_PASSER_STOP_BISHOP = 4;  // schlecht (als Malus gegenüber gut)
+constexpr int BLOCK_PASSER_STOP_KNIGHT = 8;  // gut
+constexpr int BLOCK_PASSER_STOP_BISHOP = 8;  // schlecht (als Malus gegenüber gut)
 
 // Threats (etwas härter auf Hänger / Bauern-Drohungen)
 constexpr int THR_PAWN_MINOR = 10, THR_PAWN_ROOK = 20, THR_PAWN_QUEEN = 24;

--- a/src/lilia/engine/eval.cpp
+++ b/src/lilia/engine/eval.cpp
@@ -1109,16 +1109,19 @@ static int passer_blocker_quality(const std::array<Bitboard, 6>& W,
       if (!passed) continue;
       int stop = white ? (s + 8) : (s - 8);
       if (stop < 0 || stop > 63) continue;
+      int advance =
+          white ? rank_of(static_cast<Square>(s)) : (7 - rank_of(static_cast<Square>(s)));
       Bitboard stopBB = sq_bb((Square)stop);
       if (occ & stopBB) {
+        int scale = advance;
         if (W[1] & stopBB)
-          sc += (white ? +BLOCK_PASSER_STOP_KNIGHT : -BLOCK_PASSER_STOP_KNIGHT);
+          sc += (white ? +BLOCK_PASSER_STOP_KNIGHT : -BLOCK_PASSER_STOP_KNIGHT) * scale;
         else if (W[2] & stopBB)
-          sc += (white ? -BLOCK_PASSER_STOP_BISHOP : +BLOCK_PASSER_STOP_BISHOP);
+          sc += (white ? -BLOCK_PASSER_STOP_BISHOP : +BLOCK_PASSER_STOP_BISHOP) * scale;
         if (B[1] & stopBB)
-          sc += (white ? -BLOCK_PASSER_STOP_KNIGHT : +BLOCK_PASSER_STOP_KNIGHT);
+          sc += (white ? -BLOCK_PASSER_STOP_KNIGHT : +BLOCK_PASSER_STOP_KNIGHT) * scale;
         else if (B[2] & stopBB)
-          sc += (white ? +BLOCK_PASSER_STOP_BISHOP : -BLOCK_PASSER_STOP_BISHOP);
+          sc += (white ? +BLOCK_PASSER_STOP_BISHOP : -BLOCK_PASSER_STOP_BISHOP) * scale;
       }
     }
   };


### PR DESCRIPTION
## Summary
- increase BLOCK_PASSER_STOP_KNIGHT and BLOCK_PASSER_STOP_BISHOP to widen the gap between strong and weak blockers
- scale passer blocker bonuses/penalties by pawn advancement to emphasize promotion threats

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_engine -j2`

------
https://chatgpt.com/codex/tasks/task_e_68be5b706eb48329ba025ace25fb892a