### PR TITLE
Boost advanced passer bonuses

### DIFF
--- a/include/lilia/engine/eval_shared.hpp
+++ b/include/lilia/engine/eval_shared.hpp
@@ -33,13 +33,17 @@ constexpr int BACKWARD_P = 10;
 constexpr int PHALANX = 8;
 constexpr int CANDIDATE_P = 10;
 constexpr int CONNECTED_PASSERS = 22;
-constexpr int PASSED_MG[8] = {0, 8, 16, 28, 48, 100, 130, 0};
-constexpr int PASSED_EG[8] = {0, 16, 28, 44, 72, 130, 170, 0};
-constexpr int PASS_BLOCK = 10;
-constexpr int PASS_SUPP = 8;
-constexpr int PASS_FREE = 14;
-constexpr int PASS_KBOOST = 14;
-constexpr int PASS_KBLOCK = 12;
+// Passed pawn bonuses by rank. Heavily boosted for advanced passers
+// so that near-promotion threats can outweigh small material deficits.
+constexpr int PASSED_MG[8] = {0, 8, 16, 28, 60, 150, 220, 0};
+constexpr int PASSED_EG[8] = {0, 16, 28, 44, 90, 180, 260, 0};
+
+// Additional bonuses/penalties for passer conditions
+constexpr int PASS_BLOCK = 16;   // penalty if path is blocked
+constexpr int PASS_SUPP = 16;    // own pawn support
+constexpr int PASS_FREE = 24;    // no piece ahead
+constexpr int PASS_KBOOST = 20;  // friendly king nearby
+constexpr int PASS_KBLOCK = 18;  // enemy king in front
 
 // =============================================================================
 /* King safety (SF-ähnliche Druckgewichtung & Clamp) */

--- a/src/lilia/engine/eval.cpp
+++ b/src/lilia/engine/eval.cpp
@@ -245,6 +245,8 @@ static PawnInfo pawn_structure_split(Bitboard wp, Bitboard bp, int wK, int bK, B
     }
 
     if (passed) {
+      // Apply tuned passer bonuses directly; no clamping keeps the
+      // heightened constants from being suppressed.
       int mgB = PASSED_MG[r], egB = PASSED_EG[r];
       int stop = sq + 8;
       if (stop <= 63 && (occ & sq_bb((Square)stop))) {
@@ -299,6 +301,7 @@ static PawnInfo pawn_structure_split(Bitboard wp, Bitboard bp, int wK, int bK, B
     }
 
     if (passed) {
+      // Symmetric handling for black; values are unclamped as well.
       int mgB = PASSED_MG[7 - r], egB = PASSED_EG[7 - r];
       int stop = sq - 8;
       if (stop >= 0 && (occ & sq_bb((Square)stop))) {


### PR DESCRIPTION
## Summary
- Sharpen passed pawn evaluation: stronger bonuses for advanced passers and adjusted passer condition weights.
- Document pawn bonus application in `pawn_structure_split` to ensure boosted constants are unclamped.

## Testing
- `cmake -S . -B build` *(passes after installing dependencies)*
- `cmake --build build` *(partial build, interrupted around 78% due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68be5b6ab5d88329a47f6db391717a5d