### PR TITLE
Enhance advanced passer evaluation

### DIFF
--- a/include/lilia/engine/eval_shared.hpp
+++ b/include/lilia/engine/eval_shared.hpp
@@ -35,8 +35,9 @@ constexpr int CANDIDATE_P = 10;
 constexpr int CONNECTED_PASSERS = 22;
 // Passed pawn bonuses by rank. Heavily boosted for advanced passers
 // so that near-promotion threats can outweigh small material deficits.
-constexpr int PASSED_MG[8] = {0, 8, 16, 28, 60, 150, 220, 0};
-constexpr int PASSED_EG[8] = {0, 16, 28, 44, 90, 180, 260, 0};
+// Ranks 5-7 receive extra emphasis compared to the previous tuning.
+constexpr int PASSED_MG[8] = {0, 8, 16, 30, 70, 190, 300, 0};
+constexpr int PASSED_EG[8] = {0, 16, 28, 50, 110, 220, 340, 0};
 
 // Additional bonuses/penalties for passer conditions
 constexpr int PASS_BLOCK = 16;   // penalty if path is blocked
@@ -44,6 +45,8 @@ constexpr int PASS_SUPP = 16;    // own pawn support
 constexpr int PASS_FREE = 24;    // no piece ahead
 constexpr int PASS_KBOOST = 20;  // friendly king nearby
 constexpr int PASS_KBLOCK = 18;  // enemy king in front
+constexpr int PASS_PIECE_SUPP = 12;  // defended by own piece
+constexpr int PASS_KPROX = 6;        // enemy king proximity penalty per step
 
 // =============================================================================
 /* King safety (SF-ähnliche Druckgewichtung & Clamp) */


### PR DESCRIPTION
## Summary
- Increase passed pawn bonuses for ranks 5-7 and add constants for piece support and enemy king proximity
- Incorporate piece support and opponent king distance into passer scoring within `pawn_structure_split`
- Wire new passer evaluation logic into evaluation flow

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_engine`
- `echo -e "uci\nquit\n" | ./build/bin/lilia_engine`


------
https://chatgpt.com/codex/tasks/task_e_68be5fd27d0c832982ff4ca0595362b2