### PR TITLE
Extend SEE to evaluate quiet moves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,8 +162,8 @@ function(lilia_set_perf_flags tgt)
 endfunction()
 
 # Apply flags
-lilia_set_perf_flags(lilia_engine)
-lilia_set_perf_flags(lilia_app)
+  lilia_set_perf_flags(lilia_engine)
+  lilia_set_perf_flags(lilia_app)
 
 # Global IPO fallback (non-MSVC)
 if (LILIA_LTO AND NOT MSVC)

--- a/include/lilia/model/position.hpp
+++ b/include/lilia/model/position.hpp
@@ -58,6 +58,9 @@ class Position {
   bool checkRepetition();
 
   bool inCheck() const;
+  /// Static exchange evaluation. Simulates the capture sequence on the
+  /// destination square (also for quiet moves) and returns true if the net
+  /// material gain is non-negative.
   bool see(const model::Move& m) const;
   bool isPseudoLegal(const Move& m) const;
 

--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -780,6 +780,9 @@ int Search::negamax(model::Position& pos, int depth, int alpha, int beta, int pl
       } else {
         seeGood = trivialGood ? true : pos.see(m);
       }
+    } else if (!inCheck && ply > 0 && !pos.see(m)) {
+      ++moveCount;
+      continue;  // prune quiets dropping material
     }
 
     const int mvvBefore =

--- a/src/lilia/model/position.cpp
+++ b/src/lilia/model/position.cpp
@@ -243,9 +243,6 @@ bool Position::see(const model::Move& m) const {
   using core::PieceType;
   using core::Square;
 
-  // Quiets are fine for SEE gates
-  if (!m.isCapture() && !m.isEnPassant()) return true;
-
   const auto fromP = m_board.getPiece(m.from());
   if (!fromP) return true;
 
@@ -337,16 +334,14 @@ bool Position::see(const model::Move& m) const {
     return false;
   };
 
-  // Identify captured piece and adjust occupancy
+  // Identify captured piece (if any) and adjust occupancy
   PieceType captured = PieceType::None;
-  Square capSq = to;
   if (m.isEnPassant()) {
     captured = PieceType::Pawn;
-    capSq = (us == Color::White) ? Square(int(to) - 8) : Square(int(to) + 8);
+    Square capSq =
+        (us == Color::White) ? Square(int(to) - 8) : Square(int(to) + 8);
     occ &= ~bb::sq_bb(capSq);
-  } else {
-    const auto cap = m_board.getPiece(to);
-    if (!cap) return true;  // robust
+  } else if (auto cap = m_board.getPiece(to)) {
     captured = cap->type;
     occ &= ~bb::sq_bb(to);
   }


### PR DESCRIPTION
## Summary
- Perform full static exchange evaluation on all moves, including quiet ones
- Allow search to prune quiet moves that drop material using SEE
- Document SEE behaviour

## Testing
- `cmake -S . -B build`
- `cmake --build build --target lilia_engine`


------
https://chatgpt.com/codex/tasks/task_e_68be60fbd6fc832983cd33288b5e3a80