### PR TITLE
Make engine config fully adjustable via UCI options

### DIFF
--- a/include/lilia/uci/uci.hpp
+++ b/include/lilia/uci/uci.hpp
@@ -16,16 +16,10 @@ class UCI {
   void setOption(const std::string& line);
 
   struct Options {
-    int hashMb = 64;
-    int threads = 1;
+    engine::EngineConfig cfg{};
     bool ponder = false;
     int moveOverhead = 10;
-    engine::EngineConfig toEngineConfig() const {
-      engine::EngineConfig cfg;
-      cfg.ttSizeMb = hashMb;
-      cfg.threads = threads;
-      return cfg;
-    }
+    engine::EngineConfig toEngineConfig() const { return cfg; }
   } m_options;
 
   std::string m_name = "LiliaEngine";


### PR DESCRIPTION
## Summary
- expose all `EngineConfig` parameters as UCI options
- parse `setoption` to update engine configuration and typical UCI settings

## Testing
- `cmake --build . --target lilia_engine -j 8`

------
https://chatgpt.com/codex/tasks/task_e_68be61e8dfd48329a396d3fa1585cc22