### PR TITLE
Add Texel tuner infrastructure

### DIFF
--- a/include/lilia/engine/texel_tuner.hpp
+++ b/include/lilia/engine/texel_tuner.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <cstddef>
+#include <vector>
+
+namespace lilia::engine {
+
+struct TexelSample {
+  std::vector<double> features;  // feature vector describing a position
+  double target = 0.0;           // Stockfish evaluation in centipawns
+};
+
+class TexelTuner {
+ public:
+  explicit TexelTuner(std::size_t featureCount);
+
+  void addSample(const std::vector<double>& features, double target);
+  void tune(std::size_t iterations, double k = 1.0 / 400.0, double lr = 1e-3);
+
+  const std::vector<double>& weights() const noexcept { return m_weights; }
+
+ private:
+  std::vector<TexelSample> m_samples;
+  std::vector<double> m_weights;
+};
+
+}  // namespace lilia::engine
+

--- a/src/lilia/engine/texel_tuner.cpp
+++ b/src/lilia/engine/texel_tuner.cpp
@@ -1,0 +1,33 @@
+#include "lilia/engine/texel_tuner.hpp"
+
+#include <cmath>
+
+namespace lilia::engine {
+
+TexelTuner::TexelTuner(std::size_t featureCount)
+    : m_weights(featureCount, 0.0) {}
+
+void TexelTuner::addSample(const std::vector<double>& features, double target) {
+  m_samples.push_back({features, target});
+}
+
+void TexelTuner::tune(std::size_t iterations, double k, double lr) {
+  for (std::size_t it = 0; it < iterations; ++it) {
+    for (const auto& s : m_samples) {
+      double eval = 0.0;
+      for (std::size_t i = 0; i < m_weights.size(); ++i)
+        eval += m_weights[i] * s.features[i];
+
+      const double p = 1.0 / (1.0 + std::exp(-k * eval));
+      const double t = 1.0 / (1.0 + std::exp(-k * s.target));
+      const double diff = p - t;
+
+      for (std::size_t i = 0; i < m_weights.size(); ++i) {
+        m_weights[i] -= lr * diff * k * s.features[i];
+      }
+    }
+  }
+}
+
+}  // namespace lilia::engine
+


### PR DESCRIPTION
## Summary
- Add `TexelTuner` class to perform Texel tuning using Stockfish evaluation data
- Provide gradient-descent based logistic fitting for engine evaluation parameters

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68be661a27b483299009f359d0970541