### PR TITLE
Reuse cached king squares in evaluation

### DIFF
--- a/src/lilia/engine/eval.cpp
+++ b/src/lilia/engine/eval.cpp
@@ -1615,6 +1615,9 @@ int Evaluator::evaluate(model::Position &pos) const {
   Bitboard wocc = b.getPieces(Color::White);
   Bitboard bocc = b.getPieces(Color::Black);
 
+  int wK = lsb_i(W[5]);
+  int bK = lsb_i(B[5]);
+
   // material & pst & phase & counts — aus dem Acc
   const auto &ac = pos.getEvalAcc();
   MaterialCounts mc{};
@@ -1634,8 +1637,6 @@ int Evaluator::evaluate(model::Position &pos) const {
   int phase = ac.phase;
   int curPhase = clampi(phase, 0, MAX_PHASE);
 
-  int wK = ac.kingSq[0], bK = ac.kingSq[1];
-
   PawnInfo pinfo{};
   Bitboard wPA = 0, bPA = 0, wPass = 0, bPass = 0;
   {
@@ -1649,8 +1650,7 @@ int Evaluator::evaluate(model::Position &pos) const {
       wPass = (Bitboard)ps.wPass.load(std::memory_order_relaxed);
       bPass = (Bitboard)ps.bPass.load(std::memory_order_relaxed);
     } else {
-      int wKbb = lsb_i(W[5]), bKbb = lsb_i(B[5]);
-      pinfo = pawn_structure_split(W[0], B[0], W, B, wKbb, bKbb, occ);
+      pinfo = pawn_structure_split(W[0], B[0], W, B, wK, bK, occ);
 
       wPA = white_pawn_attacks(W[0]);
       bPA = black_pawn_attacks(B[0]);
@@ -1700,8 +1700,8 @@ int Evaluator::evaluate(model::Position &pos) const {
   A.bRo = att.bRo;
   A.wQu = att.wQu;
   A.bQu = att.bQu;
-  A.wKAtt = (lsb_i(W[5]) >= 0) ? king_attacks_from((Square)lsb_i(W[5])) : 0;
-  A.bKAtt = (lsb_i(B[5]) >= 0) ? king_attacks_from((Square)lsb_i(B[5])) : 0;
+  A.wKAtt = (wK >= 0) ? king_attacks_from((Square)wK) : 0;
+  A.bKAtt = (bK >= 0) ? king_attacks_from((Square)bK) : 0;
 
   // threats
   int thr = threats(W, B, A, occ);


### PR DESCRIPTION
## Summary
- Cache white and black king squares once in `Evaluator::evaluate`
- Reuse cached king positions for pawn structure and attack map setup, dropping repeated `lsb_i` calls

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68be6933c04883298f30df524555aa73