### PR TITLE
Add SPSA-based tuner and tunable evaluation parameters

### DIFF
--- a/include/lilia/engine/eval_tune_shared.hpp
+++ b/include/lilia/engine/eval_tune_shared.hpp
@@ -1,0 +1,321 @@
+#pragma once
+#include <array>
+#include <cstdint>
+
+#include "lilia/model/core/bitboard.hpp"
+
+namespace lilia::engine {
+using namespace lilia::core;
+using namespace lilia::model;
+
+// -------- helpers (inline) --------
+inline int mirror_sq_black(int sq) noexcept {
+  return sq ^ 56;
+}
+
+// =============================================================================
+// Globale Skalen & Mischer
+// =============================================================================
+inline int MAX_PHASE = 24;     // sum both sides
+inline int BLEND_SCALE = 256;  // MG/EG-Blendskala
+
+inline int PAWN_VALUE = 100;
+inline int KNIGHT_VALUE = 320;
+inline int BISHOP_VALUE = 330;
+inline int ROOK_VALUE = 500;
+inline int QUEEN_VALUE = 900;
+
+// Tempo
+inline int TEMPO_MG = 20;
+inline int TEMPO_EG = 8;
+inline int SPACE_EG_DEN = 4;
+
+// =============================================================================
+// Pawns (leicht strenger auf Schwächen; stärkere Passer-Skalierung)
+// =============================================================================
+inline int ISO_P = 12;
+inline int DOUBLED_P = 18;
+inline int BACKWARD_P = 10;
+inline int PHALANX = 8;
+inline int CANDIDATE_P = 10;
+inline int CONNECTED_PASSERS = 22;
+// Passed pawn bonuses by rank. Heavily boosted for advanced passers
+// so that near-promotion threats can outweigh small material deficits.
+// Ranks 5-7 receive extra emphasis compared to the previous tuning.
+inline int PASSED_MG[8] = {0, 8, 16, 30, 70, 190, 300, 0};
+inline int PASSED_EG[8] = {0, 16, 28, 50, 110, 220, 340, 0};
+
+// Additional bonuses/penalties for passer conditions
+inline int PASS_BLOCK = 16;   // penalty if path is blocked
+inline int PASS_SUPP = 16;    // own pawn support
+inline int PASS_FREE = 24;    // no piece ahead
+inline int PASS_KBOOST = 20;  // friendly king nearby
+inline int PASS_KBLOCK = 18;  // enemy king in front
+inline int PASS_PIECE_SUPP = 12;  // defended by own piece
+inline int PASS_KPROX = 6;        // enemy king proximity penalty per step
+
+// =============================================================================
+/* King safety (SF-ähnliche Druckgewichtung & Clamp) */
+// =============================================================================
+inline int KS_W_N = 18, KS_W_B = 20, KS_W_R = 16, KS_W_Q = 24;
+inline int KS_RING_BONUS = 1, KS_MISS_SHIELD = 8, KS_OPEN_FILE = 10, KS_RQ_LOS = 6,
+              KS_CLAMP = 160;
+
+// King-Ring/Shield-Geometrie
+inline int KING_RING_RADIUS = 2;       // Ring-Radius (Chebyshev)
+inline int KING_SHIELD_DEPTH = 2;      // Bauernreihen vor dem König, die als „Shield“ zählen
+inline int KS_POWER_COUNT_CLAMP = 12;  // max Angriffs-Feldanzahl für Power-Akkumulation
+
+// King-safety Mischung (MG/EG)
+inline int KS_MIX_MG_Q_ON = 100;
+inline int KS_MIX_MG_Q_OFF = 45;
+inline int KS_MIX_EG_HEAVY_THRESHOLD = 2;  // # (Q+R) beider Seiten
+inline int KS_MIX_EG_IF_HEAVY = 40;
+inline int KS_MIX_EG_IF_LIGHT = 10;
+
+// =============================================================================
+// King pawn shelter / storm (leicht steiler)
+// =============================================================================
+static inline int SHELTER[8] = {0, 0, 2, 6, 12, 20, 28, 34};
+static inline int STORM[8] = {0, 6, 10, 14, 18, 22, 26, 30};
+inline int SHELTER_EG_DEN = 4;  // Shelter schwächer im EG
+
+// =============================================================================
+// Pieces/style (klassischer angehaucht)
+// =============================================================================
+inline int BISHOP_PAIR = 36;
+inline int BAD_BISHOP_PER_PAWN = 2;
+inline int BAD_BISHOP_SAME_COLOR_THRESHOLD = 4;  // ab so vielen gleichfarbigen Bauern
+inline int BAD_BISHOP_OPEN_NUM = 1;              // Faktor „offenes Zentrum“
+inline int BAD_BISHOP_OPEN_DEN = 2;
+
+inline int OUTPOST_KN = 28;
+inline int OUTPOST_DEEP_RANK_WHITE = 4;  // r >= 4
+inline int OUTPOST_DEEP_RANK_BLACK = 3;  // r <= 3
+inline int OUTPOST_DEEP_EXTRA = 6;       // Zusatz zu OUTPOST_KN bei „deep“
+inline int CENTER_CTRL = 6;              // Angriffssteuerung auf Zentrum
+inline int OUTPOST_CENTER_SQ_BONUS = 6;  // Outpost steht direkt auf d4/e4/d5/e5
+
+inline int KNIGHT_RIM = 14;
+
+inline int ROOK_OPEN = 20;
+inline int ROOK_SEMI = 12;
+inline int ROOK_ON_7TH = 26;
+inline int CONNECTED_ROOKS = 18;
+inline int ROOK_BEHIND_PASSER = 26;
+inline int ROOK_BEHIND_PASSER_HALF = ROOK_BEHIND_PASSER / 2;
+inline int ROOK_BEHIND_PASSER_THIRD = ROOK_BEHIND_PASSER / 3;
+
+// Zusatzeffekte Rook vs Königsdatei (MG-Effekt)
+inline int ROOK_SEMI_ON_KING_FILE = 6;
+inline int ROOK_OPEN_ON_KING_FILE = 10;
+
+// EG-only Rook-Extras
+inline int ROOK_PASSER_PROGRESS_START_RANK = 3;  // ab dieser „Fortschritt“-Schwelle
+inline int ROOK_PASSER_PROGRESS_MULT = ROOK_BEHIND_PASSER_THIRD;
+inline int ROOK_CUT_MIN_SEPARATION = 2;  // Mindestens 2 Linien Abstand = „cut“
+inline int ROOK_CUT_BONUS = 14;
+
+// Stopper-Qualität (Wer blockiert Passer-Stopfeld?)
+inline int BLOCK_PASSER_STOP_KNIGHT = 8;  // gut
+inline int BLOCK_PASSER_STOP_BISHOP = 8;  // schlecht (als Malus gegenüber gut)
+
+// Threats (etwas härter auf Hänger / Bauern-Drohungen)
+inline int THR_PAWN_MINOR = 10, THR_PAWN_ROOK = 20, THR_PAWN_QUEEN = 24;
+inline int HANG_MINOR = 10, HANG_ROOK = 16, HANG_QUEEN = 24;
+inline int MINOR_ON_QUEEN = 6;
+
+// Threats/Tropism Mischung
+inline int THREATS_MG_NUM = 3, THREATS_MG_DEN = 2;  // *3/2
+inline int THREATS_EG_DEN = 4;
+
+// Space (kleiner Stupser)
+inline int SPACE_BASE = 5;
+inline int SPACE_SCALE_BASE = 2;        // 2 + min(#Minors, Sättigung)
+inline int SPACE_MINOR_SATURATION = 4;  // Sättigungsgrenze
+
+// =============================================================================
+// Entwicklung & Blockaden
+// =============================================================================
+inline int DEVELOPMENT_PIECE_ON_HOME_PENALTY = 16;
+inline int DEV_MG_PHASE_CUTOFF = 12;
+inline int DEV_MG_PHASE_DEN = 12;
+inline int DEV_EG_DEN = 8;
+
+inline int PIECE_BLOCKING_PENALTY = 8;
+
+// =============================================================================
+// King-Tropism
+// =============================================================================
+inline int TROPISM_BASE_KN = 12;
+inline int TROPISM_BASE_BI = 10;
+inline int TROPISM_BASE_RO = 8;
+inline int TROPISM_BASE_QU = 6;
+inline int TROPISM_DIST_FACTOR = 2;  // base - 2*Dist
+inline int TROPISM_EG_DEN = 2;
+
+// King Aktivität EG
+inline int KING_ACTIVITY_EG_MULT = 2;
+
+// =============================================================================
+// Passed-pawn-race (EG, figurenarm)
+// =============================================================================
+inline int PASS_RACE_MAX_MINORMAJOR = 2;      // max. Leicht-/Schwerfiguren total (ohne Damen)
+constexpr bool PASS_RACE_NEED_QUEENLESS = true;  // nur ohne Damen werten
+inline int PASS_RACE_STM_ADJ = 1;             // Zugrecht-Offset (0 oder 1)
+inline int PASS_RACE_MULT = 4;
+
+// =============================================================================
+// Endgame scaling (inkl. klassischer Sonderfälle)
+// =============================================================================
+inline int FULL_SCALE = 256;
+inline int SCALE_DRAW = 0;
+inline int SCALE_VERY_DRAWISH = 96;  // ~0.375
+inline int SCALE_REDUCED = 144;      // ~0.56
+inline int SCALE_MEDIUM = 160;       // ~0.625
+inline int KN_CORNER_PAWN_SCALE = 32;
+
+// Opposites (bisschen remislastiger) – wird explizit genutzt
+inline int OPP_BISHOPS_SCALE = 190;  // /256
+
+// =============================================================================
+// Castles & Center
+// =============================================================================
+inline bool rook_on_start_square(bb::Bitboard rooks, bool white) {
+  return white ? (rooks & (bb::sq_bb(Square(0)) | bb::sq_bb(Square(7))))     // a1,h1
+               : (rooks & (bb::sq_bb(Square(56)) | bb::sq_bb(Square(63))));  // a8,h8
+}
+
+inline int CASTLE_BONUS = 28;
+
+inline int CENTER_BACK_PENALTY_Q_ON = 36;   // König im Zentrum (e/d) bei Damen auf Brett
+inline int CENTER_BACK_PENALTY_Q_OFF = 12;  // dito ohne Damen
+inline int CENTER_BACK_OPEN_FILE_OPEN = 2;  // Bewertung offener/halb-offener d/e-File...
+inline int CENTER_BACK_OPEN_FILE_SEMI = 1;  // ...als Verstärker
+inline int CENTER_BACK_OPEN_FILE_WEIGHT = 8;
+inline int ROOK_KFILE_PRESS_FREE = 2;     // bonus per un-attacked lane square
+inline int ROOK_KFILE_PRESS_PAWNATT = 3;  // penalty per lane square attacked by enemy pawn
+inline int ROOK_LIFT_SAFE = 6;
+inline int KS_ESCAPE_EMPTY = 6, KS_ESCAPE_FACTOR = 2;
+inline int EARLY_QUEEN_MALUS = 8;  // Frühe Dame vor unentwickelten Minors
+
+inline int UNCASTLED_PENALTY_Q_ON = 10;  // „nicht rochiert“ Heuristik bei Q on
+
+// =============================================================================
+// Mobility Profile & Clamp
+// =============================================================================
+static inline int KN_MOB_MG[9] = {-16, -8, -4, 0, 4, 8, 12, 16, 18};
+static inline int KN_MOB_EG[9] = {-12, -6, -2, 2, 6, 10, 12, 14, 16};
+static inline int BI_MOB_MG[14] = {-22, -12, -6, -2, 2, 6, 10, 14, 18, 22, 24, 26, 28, 30};
+static inline int BI_MOB_EG[14] = {-18, -10, -4, 0, 4, 8, 12, 16, 20, 24, 26, 28, 30, 32};
+static inline int RO_MOB_MG[15] = {-20, -12, -6, -2, 2, 6, 10, 14, 18, 22, 26, 30, 32, 34, 36};
+static inline int RO_MOB_EG[15] = {-10, -6, -2, 2, 6, 10, 14, 18, 22, 26, 30, 34, 36, 38, 40};
+static inline int QU_MOB_MG[28] = {-10, -8, -6, -4, -2, 0,  2,  4,  6,  8,  10, 12, 14, 16,
+                                      18,  20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44};
+static inline int QU_MOB_EG[28] = {-6, -4, -2, 0,  2,  4,  6,  8,  10, 12, 14, 16, 18, 20,
+                                      22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48};
+inline int MOBILITY_CLAMP = 900;
+
+// =============================================================================
+// Werte & Phase (white POV)
+// =============================================================================
+inline constexpr std::array<int, 6> VAL_MG = {82, 337, 365, 477, 1025, 0};
+inline constexpr std::array<int, 6> VAL_EG = {94, 300, 320, 500, 940, 0};
+inline constexpr std::array<int, 6> PHASE_W = {0, 1, 1, 2, 4, 0};
+
+// =============================================================================
+// PSTs (mg/eg) – unverändert
+// =============================================================================
+inline constexpr std::array<int, 64> PST_P_MG = {
+    0,  0,  0,  0,  0,  0,  0,  0,  6,  6,  2,  -6, -6, 2,  6,  6,  4,  -2, -3, 2,  2,  -3,
+    -2, 4,  6,  8,  12, 16, 16, 12, 8,  6,  8,  12, 18, 24, 24, 18, 12, 8,  12, 18, 24, 28,
+    28, 24, 18, 12, 12, 12, 12, 12, 12, 12, 12, 12, 0,  0,  0,  0,  0,  0,  0,  0};
+inline constexpr std::array<int, 64> PST_P_EG = {
+    0,  0,  0,  0,  0,  0,  0,  0,  6,  8,  4,  -2, -2, 4,  8,  6,  6,  2,  2,  6,  6,  2,
+    2,  6,  8,  12, 16, 20, 20, 16, 12, 8,  12, 18, 24, 30, 30, 24, 18, 12, 16, 24, 32, 40,
+    40, 32, 24, 16, 10, 14, 18, 22, 22, 18, 14, 10, 0,  0,  0,  0,  0,  0,  0,  0};
+inline constexpr std::array<int, 64> PST_N_MG = {
+    -50, -38, -28, -22, -22, -28, -38, -50, -32, -16, -4,  2,   2,   -4,  -16, -32,
+    -24, -2,  12,  18,  18,  12,  -2,  -24, -20, 4,   18,  26,  26,  18,  4,   -20,
+    -20, 4,   18,  26,  26,  18,  4,   -20, -24, -2,  12,  18,  18,  12,  -2,  -24,
+    -34, -16, -4,  0,   0,   -4,  -16, -34, -46, -36, -28, -24, -24, -28, -36, -46};
+inline constexpr std::array<int, 64> PST_N_EG = {
+    -36, -26, -18, -14, -14, -18, -26, -36, -26, -12, -2,  6,   6,   -2,  -12, -26,
+    -18, -2,  10,  16,  16,  10,  -2,  -18, -14, 6,   16,  22,  22,  16,  6,   -14,
+    -14, 6,   16,  22,  22,  16,  6,   -14, -18, -2,  10,  16,  16,  10,  -2,  -18,
+    -26, -12, -2,  6,   6,   -2,  -12, -26, -36, -26, -18, -14, -14, -18, -26, -36};
+inline constexpr std::array<int, 64> PST_B_MG = {
+    -26, -14, -10, -8, -8, -10, -14, -26, -12, -4,  2,  6,  6,  2,  -4,  -12,
+    -8,  4,   10,  14, 14, 10,  4,   -8,  -6,  8,   14, 20, 20, 14, 8,   -6,
+    -6,  8,   14,  20, 20, 14,  8,   -6,  -8,  4,   10, 14, 14, 10, 4,   -8,
+    -12, -4,  2,   6,  6,  2,   -4,  -12, -24, -12, -8, -6, -6, -8, -12, -24};
+inline constexpr std::array<int, 64> PST_B_EG = {
+    -18, -8, -4, -2, -2, -4, -8, -18, -8, 0,  8,  12, 12,  8,  0,  -8, -4, 8,  14, 20, 20, 14,
+    8,   -4, -2, 12, 20, 26, 26, 20,  12, -2, -2, 12, 20,  26, 26, 20, 12, -2, -4, 8,  14, 20,
+    20,  14, 8,  -4, -8, 0,  8,  12,  12, 8,  0,  -8, -16, -8, -4, -2, -2, -4, -8, -16};
+inline constexpr std::array<int, 64> PST_R_MG = {
+    0,  2,  3,  4,  4, 3, 2, 0, -2, 0,  2,  4,  4, 2, 0, -2, -3, -1, 0,  2,  2, 0,
+    -1, -3, -4, -1, 1, 2, 2, 1, -1, -4, -4, -1, 1, 2, 2, 1,  -1, -4, -3, -1, 0, 2,
+    2,  0,  -1, -3, 4, 6, 6, 8, 8,  6,  6,  4,  2, 4, 4, 6,  6,  4,  4,  2};
+inline constexpr std::array<int, 64> PST_R_EG = {
+    2, 4,  6,  8,  8, 6, 4, 2, 0, 2,  4,  6, 6, 4, 2, 0,  -1, 1,  2,  4, 4, 2,
+    1, -1, -1, 1,  2, 4, 4, 2, 1, -1, -1, 1, 2, 4, 4, 2,  1,  -1, -1, 1, 2, 4,
+    4, 2,  1,  -1, 3, 5, 7, 9, 9, 7,  5,  3, 4, 6, 8, 10, 10, 8,  6,  4};
+inline constexpr std::array<int, 64> PST_Q_MG = {
+    -24, -16, -12, -8, -8, -12, -16, -24, -16, -8,  -4,  -2, -2, -4,  -8,  -16,
+    -12, -4,  2,   4,  4,  2,   -4,  -12, -8,  -2,  4,   6,  6,  4,   -2,  -8,
+    -8,  -2,  4,   6,  6,  4,   -2,  -8,  -12, -4,  2,   4,  4,  2,   -4,  -12,
+    -16, -8,  -4,  -2, -2, -4,  -8,  -16, -24, -16, -12, -8, -8, -12, -16, -24};
+inline constexpr std::array<int, 64> PST_Q_EG = {
+    -10, -6, -2, 0,  0,  -2, -6, -10, -6, -2, 2,  4,  4,   2,  -2, -6, -2, 2,  6,  8,  8, 6,
+    2,   -2, 0,  4,  8,  12, 12, 8,   4,  0,  0,  4,  8,   12, 12, 8,  4,  0,  -2, 2,  6, 8,
+    8,   6,  2,  -2, -6, -2, 2,  4,   4,  2,  -2, -6, -10, -6, -2, 0,  0,  -2, -6, -10};
+inline constexpr std::array<int, 64> PST_K_MG = {
+    -40, -48, -52, -56, -56, -52, -48, -40, -32, -40, -44, -50, -50, -44, -40, -32,
+    -24, -32, -36, -44, -44, -36, -32, -24, -12, -20, -28, -36, -36, -28, -20, -12,
+    0,   -8,  -18, -28, -28, -18, -8,  0,   10,  18,  4,   -10, -10, 4,   18,  10,
+    20,  28,  18,  6,   6,   18,  28,  20,  28,  38,  28,  12,  12,  28,  38,  28};
+inline constexpr std::array<int, 64> PST_K_EG = {
+    -8, -4, -4, -2, -2, -4, -4, -8, -4, 2,  4,  6,  6,  4,  2,  -4, -4, 4,  10, 12, 12, 10,
+    4,  -4, -2, 6,  12, 18, 18, 12, 6,  -2, -2, 6,  12, 18, 18, 12, 6,  -2, -4, 4,  10, 12,
+    12, 10, 4,  -4, -4, 2,  4,  6,  6,  4,  2,  -4, -8, -4, -4, -2, -2, -4, -4, -8};
+
+// -------- PST accessors (inline) --------
+inline int pst_mg(PieceType pt, int sq) {
+  switch (pt) {
+    case PieceType::Pawn:
+      return PST_P_MG[sq];
+    case PieceType::Knight:
+      return PST_N_MG[sq];
+    case PieceType::Bishop:
+      return PST_B_MG[sq];
+    case PieceType::Rook:
+      return PST_R_MG[sq];
+    case PieceType::Queen:
+      return PST_Q_MG[sq];
+    case PieceType::King:
+      return PST_K_MG[sq];
+    default:
+      return 0;
+  }
+}
+inline int pst_eg(PieceType pt, int sq) {
+  switch (pt) {
+    case PieceType::Pawn:
+      return PST_P_EG[sq];
+    case PieceType::Knight:
+      return PST_N_EG[sq];
+    case PieceType::Bishop:
+      return PST_B_EG[sq];
+    case PieceType::Rook:
+      return PST_R_EG[sq];
+    case PieceType::Queen:
+      return PST_Q_EG[sq];
+    case PieceType::King:
+      return PST_K_EG[sq];
+    default:
+      return 0;
+  }
+}
+
+}  // namespace lilia::engine

--- a/tools/tune.py
+++ b/tools/tune.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""End-to-end evaluation parameter tuner.
+
+This script generates training data via Stockfish self play, labels positions
+using Stockfish evaluations converted to win/draw/loss probabilities and tunes
+engine evaluation parameters using Texel loss with a simple SPSA optimiser.
+
+The tunable parameters live in ``include/lilia/engine/eval_tune_shared.hpp``.
+After optimisation the resulting parameters can be written back as ``constexpr``
+values to be used for normal engine builds.
+
+Note: The default configuration is intentionally conservative so that the script
+can be executed in a restricted environment.  For large scale tuning (1M+
+positions) increase the ``--samples`` argument accordingly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import random
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+import chess
+import chess.engine
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+HEADER_PATH = Path(__file__).resolve().parent.parent / "include" / "lilia" / "engine" / "eval_tune_shared.hpp"
+
+
+@dataclass
+class Parameters:
+    values: Dict[str, float]
+
+    @classmethod
+    def load(cls) -> "Parameters":
+        text = HEADER_PATH.read_text(encoding="utf-8")
+        pattern = re.compile(r"inline\s+int\s+(\w+)\s*=\s*([-0-9]+)")
+        values = {m.group(1): float(m.group(2)) for m in pattern.finditer(text)}
+        return cls(values)
+
+    def save_as_constexpr(self, out_path: Path) -> None:
+        content_lines = [f"constexpr int {k} = {int(round(v))};" for k, v in self.values.items()]
+        out_path.write_text("\n".join(content_lines) + "\n", encoding="utf-8")
+
+
+# Texel formula converting centipawns to win probability.
+def cp_to_wdl(cp: float) -> float:
+    return 1.0 / (1.0 + math.exp(-cp / 400.0))
+
+
+# Simple material based evaluation using a subset of parameters.
+def evaluate_board(board: chess.Board, params: Parameters) -> float:
+    p = params.values
+    piece_values = {
+        chess.PAWN: p.get("PAWN_VALUE", 100),
+        chess.KNIGHT: p.get("KNIGHT_VALUE", 320),
+        chess.BISHOP: p.get("BISHOP_VALUE", 330),
+        chess.ROOK: p.get("ROOK_VALUE", 500),
+        chess.QUEEN: p.get("QUEEN_VALUE", 900),
+        chess.KING: 0,
+    }
+    score = 0.0
+    for piece_type in piece_values:
+        score += piece_values[piece_type] * (
+            len(board.pieces(piece_type, chess.WHITE))
+            - len(board.pieces(piece_type, chess.BLACK))
+        )
+    # Tempo bonus
+    score += p.get("TEMPO_MG", 0) if board.turn == chess.WHITE else -p.get("TEMPO_MG", 0)
+    # Bishop pair
+    if len(board.pieces(chess.BISHOP, chess.WHITE)) >= 2:
+        score += p.get("BISHOP_PAIR", 0)
+    if len(board.pieces(chess.BISHOP, chess.BLACK)) >= 2:
+        score -= p.get("BISHOP_PAIR", 0)
+    return score
+
+
+# Generate FEN positions via Stockfish self play.
+def generate_fens(engine_path: str, samples: int) -> List[str]:
+    engine = chess.engine.SimpleEngine.popen_uci(engine_path)
+    fens = []
+    board = chess.Board()
+    while len(fens) < samples:
+        result = engine.play(board, chess.engine.Limit(depth=1))
+        board.push(result.move)
+        fens.append(board.fen())
+        if board.is_game_over():
+            board.reset()
+    engine.quit()
+    return fens
+
+
+# Label positions with Stockfish evaluation converted to WDL probability.
+def label_fens(engine_path: str, fens: Iterable[str]) -> List[float]:
+    engine = chess.engine.SimpleEngine.popen_uci(engine_path)
+    labels = []
+    for fen in fens:
+        board = chess.Board(fen)
+        info = engine.analyse(board, chess.engine.Limit(depth=10))
+        cp = info["score"].white().score(mate_score=10000)
+        labels.append(cp_to_wdl(float(cp)))
+    engine.quit()
+    return labels
+
+
+# Texel loss (logistic cross entropy).
+def texel_loss(pred: np.ndarray, target: np.ndarray) -> float:
+    eps = 1e-12
+    return float(-np.mean(target * np.log(pred + eps) + (1 - target) * np.log(1 - pred + eps)))
+
+
+# SPSA optimiser.
+def spsa_optimize(params: Parameters, fens: List[str], labels: List[float],
+                  iterations: int = 100, a: float = 0.1, c: float = 0.1) -> Parameters:
+    keys = list(params.values.keys())
+    theta = np.array([params.values[k] for k in keys], dtype=float)
+    labels_np = np.array(labels, dtype=float)
+
+    def evaluate(theta_vec: np.ndarray) -> float:
+        p_dict = {k: v for k, v in zip(keys, theta_vec)}
+        local_params = Parameters(p_dict)
+        preds = [cp_to_wdl(evaluate_board(chess.Board(f), local_params)) for f in fens]
+        return texel_loss(np.array(preds), labels_np)
+
+    for k in range(1, iterations + 1):
+        alpha = a / (k ** 0.602)
+        gamma = c / (k ** 0.101)
+        delta = np.array([random.choice([-1, 1]) for _ in theta])
+        loss_plus = evaluate(theta + gamma * delta)
+        loss_minus = evaluate(theta - gamma * delta)
+        grad = (loss_plus - loss_minus) / (2.0 * gamma * delta)
+        theta -= alpha * grad
+    tuned = Parameters({k: v for k, v in zip(keys, theta)})
+    return tuned
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="End-to-end SPSA tuner")
+    parser.add_argument("--stockfish", default="stockfish", help="Path to Stockfish binary")
+    parser.add_argument("--samples", type=int, default=100, help="Number of FEN samples to generate")
+    parser.add_argument("--iterations", type=int, default=50, help="Number of SPSA iterations")
+    parser.add_argument("--export", type=Path, help="Export tuned parameters to header")
+    args = parser.parse_args()
+
+    params = Parameters.load()
+    fens = generate_fens(args.stockfish, args.samples)
+    labels = label_fens(args.stockfish, fens)
+    tuned = spsa_optimize(params, fens, labels, iterations=args.iterations)
+
+    if args.export:
+        tuned.save_as_constexpr(args.export)
+        print(f"Exported tuned parameters to {args.export}")
+    else:
+        for k, v in tuned.values.items():
+            print(f"{k} = {v:.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `eval_tune_shared.hpp` with inline evaluation parameters and piece values for optimisation
- Introduce `tools/tune.py` script to generate FENs via Stockfish, label them, optimise parameters using SPSA and export tuned values
- Include simple material-based evaluation and Texel loss calculation

## Testing
- `cmake --build build`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68be738f00ec8329a5339b713f5dc7fa