### PR TITLE
Extend LMP pruning to depth 4

### DIFF
--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -792,13 +792,18 @@ int Search::negamax(model::Position& pos, int depth, int alpha, int beta, int pl
                                         : 0;
 
     // LMP (relaxed when improving)  (Step 2)
-    if (!inCheck && !isPV && isQuiet && depth <= 3 && !tacticalQuiet && !isQuietHeavy) {
-      int limit = depth * depth;  // 1,4,9
-      int h = history[m.from()][m.to()] + (quietHist[pidx(moverPt)][m.to()] >> 1);
-      if (prevOk) h += contHist[pidx(prevPt)][prev.to()][m.from()][m.to()] >> 1;
+    if (!inCheck && !isPV && isQuiet && depth <= 4 && !tacticalQuiet &&
+        !isQuietHeavy) {
+      int limit = depth * depth;  // 1,4,9,16
+      int h = history[m.from()][m.to()] +
+              (quietHist[pidx(moverPt)][m.to()] >> 1);
+      if (prevOk)
+        h += contHist[pidx(prevPt)][prev.to()][m.from()][m.to()] >> 1;
       if (h < -8000) limit = std::max(1, limit - 1);
 
-      int futMarg = FUT_MARGIN[depth] + (improving ? 32 : 0);
+      int futMarg =
+          (depth <= 3 ? FUT_MARGIN[depth] : FUT_MARGIN[3] + 32) +
+          (improving ? 32 : 0);
       if (staticEval + futMarg <= alpha + 32 && moveCount >= limit) {
         ++moveCount;
         continue;


### PR DESCRIPTION
## Summary
- Extend late-move pruning to consider depth 4, keeping tactical quiet checks intact
- Tune futility margin when depth is 4 to maintain search strength

## Testing
- `cmake -S . -B build` *(fails: Cannot find source file: tools/tune.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68bea499f9cc832980c5b28a1101cee5