### PR TITLE
search: prune poor quiet heavy moves

### DIFF
--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -838,6 +838,16 @@ int Search::negamax(model::Position& pos, int depth, int alpha, int beta, int pl
       }
     }
 
+    // Prune very bad quiet heavy pieces early
+    if (allowFutility && isQuietHeavy && depth <= 3 && !excludedMove) {
+      int histScore = history[m.from()][m.to()] + (quietHist[pidx(moverPt)][m.to()] >> 1);
+      if (prevOk) histScore += contHist[pidx(prevPt)][prev.to()][m.from()][m.to()] >> 1;
+      if (staticEval + FUT_MARGIN[depth] <= alpha && histScore < -10000) {
+        ++moveCount;
+        continue;
+      }
+    }
+
     // SEE pruning (seltener): erst billige Material-Heuristik prüfen
     bool seeGood = true;
     if (m.isCapture()) {


### PR DESCRIPTION
## Summary
- skip quiet heavy moves with very negative history when static eval is far below alpha
- place pruning before SEE checks

## Testing
- `cmake --build . --target engine_tests`
- `ctest --test-dir .`

------
https://chatgpt.com/codex/tasks/task_e_68bea4986e3483299a908499e60368f8