### PR TITLE
Add central file activity bonus for rooks

### DIFF
--- a/include/lilia/engine/eval_shared.hpp
+++ b/include/lilia/engine/eval_shared.hpp
@@ -143,6 +143,8 @@ constexpr int ROOK_SEMI = 10;
 constexpr int ROOK_ON_7TH = 20;
 constexpr int CONNECTED_ROOKS = 14;
 
+constexpr int ROOK_CENTRAL_FILE = 6;  // rooks on or controlling c–f files
+
 constexpr int ROOK_BEHIND_PASSER = 24;
 constexpr int ROOK_BEHIND_PASSER_HALF = ROOK_BEHIND_PASSER / 2;
 constexpr int ROOK_BEHIND_PASSER_THIRD = ROOK_BEHIND_PASSER / 3;


### PR DESCRIPTION
## Summary
- remove stale comment from rook_activity
- reward rooks that occupy or control central files c–f via new ROOK_CENTRAL_FILE bonus
- attempted to rerun tuning but no `tune` target or option was found

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --timeout 30`
- `cmake --build . --target tune` *(fails: No rule to make target 'tune')*

------
https://chatgpt.com/codex/tasks/task_e_68c174a63ef88329a7d8afbcf843ed86