### PR TITLE
Take root snapshot for SMP helpers

### DIFF
--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -1645,12 +1645,15 @@ int Search::search_root_lazy_smp(model::Position& pos, int maxDepth,
 
   int mainScore = 0;
 
+  // Snapshot der Ausgangsstellung anlegen, bevor Helfer starten
+  const model::Position rootSnapshot = pos;
+
   // Helfer starten
   std::vector<std::future<int>> futs;
   futs.reserve(threads - 1);
   for (int t = 1; t < threads; ++t) {
-    futs.emplace_back(pool.submit([&, tid = t] {
-      model::Position local = pos;
+    futs.emplace_back(pool.submit([rootSnapshot, &workers, maxDepth, stop, tid = t] {
+      model::Position local = rootSnapshot;
       // Helfer: Root-Ordering möglichst nicht vom TT-Move abhängig machen,
       // damit Main deterministischer bleibt (optional: cfg-Flag verwenden).
       return workers[tid]->search_root_single(local, maxDepth, stop, /*maxNodes*/ 0);


### PR DESCRIPTION
## Summary
- snapshot the root position before launching helper workers
- update worker lambda to copy from the snapshot instead of the live position

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2faa549048329b46e165e2ad0ade2