### PR TITLE
Improve load game workflow with PGN validation

### DIFF
--- a/include/lilia/model/fen_validator.hpp
+++ b/include/lilia/model/fen_validator.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace lilia::model::fen {
+
+// Performs a basic structural validation of the provided FEN string.
+// The function checks the standard six fields and validates board layout,
+// side to move, castling rights, en-passant square as well as halfmove and
+// fullmove counters. The check matches the lightweight logic that was
+// previously embedded inside the start screen UI.
+bool is_basic_fen_valid(const std::string& fen);
+
+}  // namespace lilia::model::fen
+

--- a/include/lilia/model/pgn_parser.hpp
+++ b/include/lilia/model/pgn_parser.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace lilia::model::pgn {
+
+struct ParsedPgn {
+  std::string sanitized;              // PGN text stripped from comments/variations
+  std::string startFen;               // Starting position used for replay
+  std::string finalFen;               // Final position after all moves
+  std::vector<std::string> movesSan;  // SAN tokens (sanitized)
+  std::vector<std::string> movesUci;  // Corresponding UCI moves
+};
+
+// Parses the given PGN string. On success, returns a populated ParsedPgn
+// containing the sanitized move list and derived positions. On failure,
+// returns std::nullopt and, if errorOut is provided, writes a short
+// explanation into it.
+std::optional<ParsedPgn> parse(const std::string& text, std::string* errorOut = nullptr);
+
+// Convenience helper that simply returns whether the provided PGN can be
+// parsed successfully.
+bool is_valid(const std::string& text);
+
+}  // namespace lilia::model::pgn
+

--- a/include/lilia/view/start_screen.hpp
+++ b/include/lilia/view/start_screen.hpp
@@ -2,6 +2,7 @@
 
 #include <SFML/Graphics.hpp>
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -17,6 +18,8 @@ struct StartConfig {
   bool blackIsBot{true};
   BotType blackBot{BotType::Lilia};
   std::string fen{core::START_FEN};
+  std::string pgn{};
+  bool loadFromPgn{false};
   int timeBaseSeconds{300};     // default 5 minutes
   int timeIncrementSeconds{0};  // default 0s increment
   bool timeEnabled{true};       // whether clocks are used
@@ -74,6 +77,12 @@ class StartScreen {
   sf::Text m_startText;
   sf::Text m_creditText;
 
+  // Load game header
+  sf::Text m_loadHeader;
+  sf::Text m_fenLabel;
+  sf::Text m_pgnLabel;
+  sf::Text m_pgnStatusText;
+
   // Palette selection UI
   sf::RectangleShape m_paletteButton;
   sf::Text m_paletteText;
@@ -88,14 +97,30 @@ class StartScreen {
   sf::RectangleShape m_fenPopup;
   sf::RectangleShape m_fenInputBox;
   sf::Text m_fenInputText;
+  sf::RectangleShape m_pgnInputBox;
+  sf::Text m_pgnInputText;
   sf::RectangleShape m_fenBackBtn;
   sf::RectangleShape m_fenContinueBtn;
   sf::Text m_fenBackText;
   sf::Text m_fenContinueText;
   sf::Text m_fenErrorText;
   std::string m_fenString;
+  std::string m_pgnString;
   sf::Clock m_errorClock;
   bool m_showError{false};
+
+  // Warning popup when invalid load data is supplied
+  bool m_showLoadWarning{false};
+  bool m_warnFenInvalid{false};
+  bool m_warnPgnInvalid{false};
+  sf::RectangleShape m_warningBackdrop;
+  sf::RectangleShape m_warningPanel;
+  sf::Text m_warningTitle;
+  sf::Text m_warningMessage;
+  sf::RectangleShape m_warningCancelBtn;
+  sf::RectangleShape m_warningProceedBtn;
+  sf::Text m_warningCancelText;
+  sf::Text m_warningProceedText;
 
   // time control state
   int m_baseSeconds{300};
@@ -139,6 +164,7 @@ class StartScreen {
   bool handleMouse(sf::Vector2f pos, StartConfig &cfg);
   bool handleFenMouse(sf::Vector2f pos, StartConfig &cfg);
   bool isValidFen(const std::string &fen);
+  void updateWarningMessage();
   void updateTimeToggle();
   void processHoldRepeater(HoldRepeater &r, const sf::FloatRect &bounds, sf::Vector2f mouse,
                            std::function<void()> stepFn, float initialDelay = 0.35f,

--- a/src/lilia/model/fen_validator.cpp
+++ b/src/lilia/model/fen_validator.cpp
@@ -1,0 +1,93 @@
+#include "lilia/model/fen_validator.hpp"
+
+#include <cctype>
+#include <sstream>
+
+namespace lilia::model::fen {
+
+namespace {
+
+bool is_non_negative_int(const std::string& s) {
+  if (s.empty()) return false;
+  for (char c : s) {
+    if (!std::isdigit(static_cast<unsigned char>(c))) return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+bool is_basic_fen_valid(const std::string& fen) {
+  std::istringstream ss(fen);
+  std::string fields[6];
+  for (int i = 0; i < 6; ++i) {
+    if (!(ss >> fields[i])) return false;
+  }
+
+  std::string extra;
+  if (ss >> extra) return false;
+
+  // Board layout
+  int rankCount = 0;
+  int i = 0;
+  const std::string& board = fields[0];
+  while (i < static_cast<int>(board.size())) {
+    int fileSum = 0;
+    while (i < static_cast<int>(board.size()) && board[i] != '/') {
+      char c = board[i++];
+      if (std::isdigit(static_cast<unsigned char>(c))) {
+        int n = c - '0';
+        if (n <= 0 || n > 8) return false;
+        fileSum += n;
+      } else {
+        switch (c) {
+          case 'p':
+          case 'r':
+          case 'n':
+          case 'b':
+          case 'q':
+          case 'k':
+          case 'P':
+          case 'R':
+          case 'N':
+          case 'B':
+          case 'Q':
+          case 'K':
+            fileSum += 1;
+            break;
+          default:
+            return false;
+        }
+      }
+      if (fileSum > 8) return false;
+    }
+    if (fileSum != 8) return false;
+    ++rankCount;
+    if (i < static_cast<int>(board.size()) && board[i] == '/') ++i;
+  }
+  if (rankCount != 8) return false;
+
+  // Side to move
+  if (!(fields[1] == "w" || fields[1] == "b")) return false;
+
+  // Castling rights
+  if (!(fields[2] == "-" || fields[2].find_first_not_of("KQkq") == std::string::npos))
+    return false;
+
+  // En-passant square
+  if (!(fields[3] == "-")) {
+    if (fields[3].size() != 2) return false;
+    if (fields[3][0] < 'a' || fields[3][0] > 'h') return false;
+    if (!(fields[3][1] == '3' || fields[3][1] == '6')) return false;
+  }
+
+  // Halfmove and fullmove counters
+  if (!is_non_negative_int(fields[4])) return false;
+  if (!is_non_negative_int(fields[5])) return false;
+  if (std::stoi(fields[5]) <= 0) return false;
+
+  return true;
+}
+
+}  // namespace lilia::model::fen
+

--- a/src/lilia/model/pgn_parser.cpp
+++ b/src/lilia/model/pgn_parser.cpp
@@ -1,0 +1,456 @@
+#include "lilia/model/pgn_parser.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <optional>
+#include <sstream>
+
+#include "lilia/chess_types.hpp"
+#include "lilia/constants.hpp"
+#include "lilia/model/chess_game.hpp"
+#include "lilia/model/fen_validator.hpp"
+#include "lilia/uci/uci_helper.hpp"
+
+namespace lilia::model::pgn {
+
+namespace {
+
+using core::PieceType;
+using core::Square;
+
+bool is_result_token(const std::string& token) {
+  return token == "1-0" || token == "0-1" || token == "1/2-1/2" || token == "*";
+}
+
+bool is_all_digits(const std::string& token) {
+  return !token.empty() &&
+         std::all_of(token.begin(), token.end(), [](unsigned char c) { return std::isdigit(c) != 0; });
+}
+
+bool is_nag(const std::string& token) {
+  return !token.empty() && token.front() == '$';
+}
+
+void append_sanitized_token(std::string& out, const std::string& token) {
+  if (!out.empty()) out.push_back(' ');
+  out.append(token);
+}
+
+struct SanDescriptor {
+  PieceType piece{PieceType::Pawn};
+  bool castleKing{false};
+  bool castleQueen{false};
+  bool capture{false};
+  std::optional<int> srcFile;
+  std::optional<int> srcRank;
+  int dstFile{-1};
+  int dstRank{-1};
+  PieceType promotion{PieceType::None};
+  bool check{false};
+  bool mate{false};
+};
+
+bool parse_san_descriptor(const std::string& token, SanDescriptor& desc, std::string& error) {
+  std::string core = token;
+  // Remove trailing annotations like +, #, !, ?
+  while (!core.empty()) {
+    char back = core.back();
+    if (back == '+' || back == '#' || back == '!' || back == '?') {
+      if (back == '+') desc.check = true;
+      if (back == '#') desc.mate = true;
+      core.pop_back();
+    } else {
+      break;
+    }
+  }
+
+  if (core == "O-O" || core == "0-0") {
+    desc.castleKing = true;
+    desc.piece = PieceType::King;
+    return true;
+  }
+  if (core == "O-O-O" || core == "0-0-0") {
+    desc.castleQueen = true;
+    desc.piece = PieceType::King;
+    return true;
+  }
+
+  // Remove trailing "e.p." if present
+  if (core.size() > 4) {
+    std::string lower;
+    lower.resize(core.size());
+    std::transform(core.begin(), core.end(), lower.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+    auto pos = lower.find("e.p.");
+    if (pos != std::string::npos) core.erase(pos);
+  }
+
+  // Promotion handling
+  auto eqPos = core.find('=');
+  if (eqPos != std::string::npos && eqPos + 1 < core.size()) {
+    char promo = core[eqPos + 1];
+    switch (promo) {
+      case 'q':
+      case 'Q':
+        desc.promotion = PieceType::Queen;
+        break;
+      case 'r':
+      case 'R':
+        desc.promotion = PieceType::Rook;
+        break;
+      case 'b':
+      case 'B':
+        desc.promotion = PieceType::Bishop;
+        break;
+      case 'n':
+      case 'N':
+        desc.promotion = PieceType::Knight;
+        break;
+      default:
+        error = "Unsupported promotion piece in PGN.";
+        return false;
+    }
+    core.erase(eqPos);
+  }
+
+  if (core.size() < 2) {
+    error = "Malformed SAN token.";
+    return false;
+  }
+
+  char fileChar = core[core.size() - 2];
+  char rankChar = core[core.size() - 1];
+  if (fileChar < 'a' || fileChar > 'h' || rankChar < '1' || rankChar > '8') {
+    error = "Destination square missing in SAN token.";
+    return false;
+  }
+  desc.dstFile = fileChar - 'a';
+  desc.dstRank = rankChar - '1';
+  core.erase(core.size() - 2, 2);
+
+  desc.piece = PieceType::Pawn;
+  std::size_t idx = 0;
+  if (!core.empty()) {
+    char lead = core[0];
+    switch (lead) {
+      case 'K':
+        desc.piece = PieceType::King;
+        idx = 1;
+        break;
+      case 'Q':
+        desc.piece = PieceType::Queen;
+        idx = 1;
+        break;
+      case 'R':
+        desc.piece = PieceType::Rook;
+        idx = 1;
+        break;
+      case 'B':
+        desc.piece = PieceType::Bishop;
+        idx = 1;
+        break;
+      case 'N':
+        desc.piece = PieceType::Knight;
+        idx = 1;
+        break;
+      default:
+        desc.piece = PieceType::Pawn;
+        break;
+    }
+  }
+
+  for (; idx < core.size(); ++idx) {
+    char c = core[idx];
+    if (c == 'x') {
+      desc.capture = true;
+      continue;
+    }
+    if (c >= 'a' && c <= 'h') {
+      desc.srcFile = c - 'a';
+      continue;
+    }
+    if (c >= '1' && c <= '8') {
+      desc.srcRank = c - '1';
+      continue;
+    }
+    // Ignore anything else silently for robustness
+  }
+
+  return true;
+}
+
+int file_of(Square sq) { return static_cast<int>(sq) & 7; }
+int rank_of(Square sq) { return static_cast<int>(sq) >> 3; }
+
+bool analyze_move(const model::ChessGame& game, const model::Move& move, bool& givesCheck, bool& givesMate) {
+  model::ChessGame copy = game;
+  copy.doMove(move.from(), move.to(), move.promotion());
+  auto side = copy.getGameState().sideToMove;
+  givesCheck = copy.isKingInCheck(side);
+  if (!givesCheck) {
+    givesMate = false;
+    return true;
+  }
+  const auto& legal = copy.generateLegalMoves();
+  givesMate = legal.empty();
+  return true;
+}
+
+bool move_matches_descriptor(const SanDescriptor& desc, const model::ChessGame& game,
+                             const model::Move& move, bool enforceCheck, bool enforceMate) {
+  const auto piece = game.getPiece(move.from());
+  if (piece.type == PieceType::None) return false;
+
+  if (desc.castleKing || desc.castleQueen) {
+    if (!move.isCastle()) return false;
+    if (desc.castleKing && move.castle() != model::CastleSide::KingSide) return false;
+    if (desc.castleQueen && move.castle() != model::CastleSide::QueenSide) return false;
+    if (enforceCheck || enforceMate) {
+      bool givesCheck = false, givesMate = false;
+      analyze_move(game, move, givesCheck, givesMate);
+      if (enforceCheck && !givesCheck) return false;
+      if (enforceMate && !givesMate) return false;
+    }
+    return true;
+  }
+
+  if (piece.type != desc.piece) return false;
+
+  if (desc.dstFile != file_of(move.to()) || desc.dstRank != rank_of(move.to())) return false;
+
+  if (desc.srcFile && *desc.srcFile != file_of(move.from())) return false;
+  if (desc.srcRank && *desc.srcRank != rank_of(move.from())) return false;
+
+  if (desc.capture && !(move.isCapture() || move.isEnPassant())) return false;
+  if (!desc.capture && (move.isCapture() || move.isEnPassant())) return false;
+
+  if (desc.promotion != PieceType::None && move.promotion() != desc.promotion) return false;
+  if (desc.promotion == PieceType::None && move.promotion() != PieceType::None) return false;
+
+  if (enforceCheck || enforceMate) {
+    bool givesCheck = false, givesMate = false;
+    analyze_move(game, move, givesCheck, givesMate);
+    if (enforceCheck && !givesCheck) return false;
+    if (enforceMate && !givesMate) return false;
+  }
+
+  return true;
+}
+
+std::vector<std::string> tokenize(const std::string& text) {
+  std::vector<std::string> tokens;
+  std::string current;
+  bool inBraceComment = false;
+  bool inLineComment = false;
+  int parenDepth = 0;
+
+  auto flush = [&]() {
+    if (!current.empty()) {
+      tokens.push_back(current);
+      current.clear();
+    }
+  };
+
+  const auto pushChar = [&](char c) { current.push_back(c); };
+
+  for (std::size_t i = 0; i < text.size(); ++i) {
+    char c = text[i];
+    if (inBraceComment) {
+      if (c == '}') inBraceComment = false;
+      continue;
+    }
+    if (inLineComment) {
+      if (c == '\n' || c == '\r') inLineComment = false;
+      continue;
+    }
+    if (c == '{') {
+      flush();
+      inBraceComment = true;
+      continue;
+    }
+    if (c == ';') {
+      flush();
+      inLineComment = true;
+      continue;
+    }
+    if (c == '(') {
+      ++parenDepth;
+      flush();
+      continue;
+    }
+    if (c == ')') {
+      if (parenDepth > 0) --parenDepth;
+      flush();
+      continue;
+    }
+    if (parenDepth > 0) continue;
+    if (std::isspace(static_cast<unsigned char>(c))) {
+      flush();
+      continue;
+    }
+    if (c == '.') {
+      flush();
+      continue;
+    }
+    if (c == '[') {
+      // Tags should have been removed already; just skip until next ']'
+      flush();
+      while (i < text.size() && text[i] != ']') ++i;
+      continue;
+    }
+    pushChar(c);
+  }
+  flush();
+
+  // Filter tokens: remove move numbers, results, NAGs etc.
+  std::vector<std::string> filtered;
+  filtered.reserve(tokens.size());
+  for (auto& tok : tokens) {
+    if (tok.empty()) continue;
+    if (is_result_token(tok)) continue;
+    if (is_all_digits(tok)) continue;
+    if (is_nag(tok)) continue;
+    if (tok == "e.p.") continue;
+
+    // Handle tokens like "2..." or "1...Nc6"
+    if (tok.find('...') != std::string::npos) {
+      auto pos = tok.find("...");
+      if (pos == tok.size() - 3) continue;
+      tok = tok.substr(pos + 3);
+    }
+    auto dotPos = tok.rfind('.');
+    if (dotPos != std::string::npos) {
+      if (dotPos == tok.size() - 1) continue;
+      tok = tok.substr(dotPos + 1);
+    }
+
+    filtered.push_back(tok);
+  }
+
+  return filtered;
+}
+
+}  // namespace
+
+std::optional<ParsedPgn> parse(const std::string& text, std::string* errorOut) {
+  ParsedPgn parsed;
+  parsed.startFen = core::START_FEN;
+  parsed.finalFen = core::START_FEN;
+  parsed.sanitized.clear();
+  parsed.movesSan.clear();
+  parsed.movesUci.clear();
+
+  std::string error;
+
+  std::string withoutTags;
+  withoutTags.reserve(text.size());
+  bool inTag = false;
+  bool setUpTagOne = false;
+  bool haveFenTag = false;
+  std::string fenTagValue;
+
+  for (std::size_t i = 0; i < text.size(); ++i) {
+    char c = text[i];
+    if (!inTag && c == '[') {
+      inTag = true;
+      std::size_t end = text.find(']', i + 1);
+      if (end == std::string::npos) {
+        if (errorOut) *errorOut = "Unterminated PGN tag.";
+        return std::nullopt;
+      }
+      std::string tagContent = text.substr(i + 1, end - i - 1);
+      std::istringstream tagStream(tagContent);
+      std::string key;
+      tagStream >> key;
+      if (!key.empty()) {
+        auto quotePos = tagContent.find('"');
+        std::string value;
+        if (quotePos != std::string::npos) {
+          auto quoteEnd = tagContent.find('"', quotePos + 1);
+          if (quoteEnd != std::string::npos)
+            value = tagContent.substr(quotePos + 1, quoteEnd - quotePos - 1);
+        }
+        if (key == "SetUp") setUpTagOne = (value == "1");
+        if (key == "FEN" && !value.empty()) {
+          fenTagValue = value;
+          haveFenTag = true;
+        }
+      }
+      i = end;
+      inTag = false;
+      continue;
+    }
+    withoutTags.push_back(c);
+  }
+
+  if (haveFenTag) {
+    if (!model::fen::is_basic_fen_valid(fenTagValue)) {
+      if (errorOut) *errorOut = "FEN tag inside PGN is invalid.";
+      return std::nullopt;
+    }
+    parsed.startFen = fenTagValue;
+  }
+
+  if (!haveFenTag && setUpTagOne) {
+    if (errorOut) *errorOut = "PGN has SetUp=1 but missing FEN tag.";
+    return std::nullopt;
+  }
+
+  auto tokens = tokenize(withoutTags);
+  if (tokens.empty()) {
+    if (errorOut) *errorOut = "PGN does not contain any moves.";
+    return std::nullopt;
+  }
+
+  model::ChessGame game;
+  game.setPosition(parsed.startFen);
+
+  const auto appendToken = [&](const std::string& t) { append_sanitized_token(parsed.sanitized, t); };
+
+  for (const auto& tok : tokens) {
+    SanDescriptor desc;
+    if (!parse_san_descriptor(tok, desc, error)) {
+      if (errorOut) *errorOut = error;
+      return std::nullopt;
+    }
+
+    const auto& legal = game.generateLegalMoves();
+    model::Move matched;
+    bool found = false;
+    bool enforceCheck = desc.check;
+    bool enforceMate = desc.mate;
+
+    for (const auto& mv : legal) {
+      if (move_matches_descriptor(desc, game, mv, enforceCheck, enforceMate)) {
+        if (found) {
+          if (errorOut) *errorOut = "Ambiguous SAN move in PGN.";
+          return std::nullopt;
+        }
+        matched = mv;
+        found = true;
+      }
+    }
+
+    if (!found) {
+      if (errorOut) *errorOut = "Illegal SAN move in PGN.";
+      return std::nullopt;
+    }
+
+    parsed.movesSan.push_back(tok);
+    parsed.movesUci.push_back(move_to_uci(matched));
+    appendToken(tok);
+
+    game.doMove(matched.from(), matched.to(), matched.promotion());
+  }
+
+  parsed.finalFen = game.getFen();
+  return parsed;
+}
+
+bool is_valid(const std::string& text) {
+  return parse(text, nullptr).has_value();
+}
+
+}  // namespace lilia::model::pgn
+

--- a/src/lilia/view/start_screen.cpp
+++ b/src/lilia/view/start_screen.cpp
@@ -9,6 +9,8 @@
 #include <unordered_map>
 
 #include "lilia/bot/bot_info.hpp"
+#include "lilia/model/fen_validator.hpp"
+#include "lilia/model/pgn_parser.hpp"
 #include "lilia/view/color_palette_manager.hpp"
 #include "lilia/view/render_constants.hpp"
 
@@ -68,6 +70,14 @@ inline void leftCenterText(sf::Text& t, const sf::FloatRect& box, float padX, fl
   t.setPosition(snapf(box.left + padX), snapf(box.top + box.height / 2.f + dy));
 }
 
+inline std::string trimCopy(const std::string& s) {
+  std::size_t start = 0;
+  while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start]))) ++start;
+  std::size_t end = s.size();
+  while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1]))) --end;
+  return s.substr(start, end - start);
+}
+
 void drawVerticalGradient(sf::RenderWindow& window, sf::Color top, sf::Color bottom) {
   sf::VertexArray va(sf::TriangleStrip, 4);
   auto size = window.getSize();
@@ -99,71 +109,6 @@ std::vector<BotType> availableBots() {
 }
 std::string botDisplayName(BotType t) {
   return getBotConfig(t).info.name;
-}
-
-// FEN validator (basic)
-bool basicFenCheck(const std::string& fen) {
-  std::istringstream ss(fen);
-  std::string fields[6];
-  for (int i = 0; i < 6; ++i)
-    if (!(ss >> fields[i])) return false;
-  std::string extra;
-  if (ss >> extra) return false;
-  {
-    int rankCount = 0, i = 0;
-    while (i < (int)fields[0].size()) {
-      int fileSum = 0;
-      while (i < (int)fields[0].size() && fields[0][i] != '/') {
-        char c = fields[0][i++];
-        if (std::isdigit((unsigned char)c)) {
-          int n = c - '0';
-          if (n <= 0 || n > 8) return false;
-          fileSum += n;
-        } else {
-          switch (c) {
-            case 'p':
-            case 'r':
-            case 'n':
-            case 'b':
-            case 'q':
-            case 'k':
-            case 'P':
-            case 'R':
-            case 'N':
-            case 'B':
-            case 'Q':
-            case 'K':
-              fileSum += 1;
-              break;
-            default:
-              return false;
-          }
-        }
-        if (fileSum > 8) return false;
-      }
-      if (fileSum != 8) return false;
-      ++rankCount;
-      if (i < (int)fields[0].size() && fields[0][i] == '/') ++i;
-    }
-    if (rankCount != 8) return false;
-  }
-  if (!(fields[1] == "w" || fields[1] == "b")) return false;
-  if (!(fields[2] == "-" || fields[2].find_first_not_of("KQkq") == std::string::npos)) return false;
-  if (!(fields[3] == "-")) {
-    if (fields[3].size() != 2) return false;
-    if (fields[3][0] < 'a' || fields[3][0] > 'h') return false;
-    if (!(fields[3][1] == '3' || fields[3][1] == '6')) return false;
-  }
-  auto isNonNegInt = [](const std::string& s) {
-    if (s.empty()) return false;
-    for (char c : s)
-      if (!std::isdigit((unsigned char)c)) return false;
-    return true;
-  };
-  if (!isNonNegInt(fields[4])) return false;
-  if (!isNonNegInt(fields[5])) return false;
-  if (std::stoi(fields[5]) <= 0) return false;
-  return true;
 }
 
 inline std::string formatHMS(int totalSeconds) {
@@ -355,23 +300,64 @@ void StartScreen::setupUI() {
   m_fenErrorText.setFillColor(colInvalid);
   centerText(m_fenErrorText, m_startBtn.getGlobalBounds(), -(m_startBtn.getSize().y / 2.f + 15.f));
 
-  // -------- Inline FEN (50% smaller height) --------
-  const float fenW = PANEL_W * 0.95f;
-  const float fenH = 22.f;  // 44 * 0.5
-  const float fenY = m_startBtn.getPosition().y + m_startBtn.getSize().y + 25.f;
-  const float fenX = x0 + (PANEL_W - fenW) * 0.5f;
+  // Load game section (FEN & PGN)
+  const float loadWidth = PANEL_W * 0.95f;
+  const float loadX = x0 + (PANEL_W - loadWidth) * 0.5f;
+  const float loadTop = m_startBtn.getPosition().y + m_startBtn.getSize().y + 20.f;
+
+  m_loadHeader.setFont(m_font);
+  m_loadHeader.setString("Load Game");
+  m_loadHeader.setCharacterSize(18);
+  m_loadHeader.setFillColor(colText);
+  m_loadHeader.setPosition(snapf(loadX), snapf(loadTop));
+
+  m_fenLabel.setFont(m_font);
+  m_fenLabel.setCharacterSize(14);
+  m_fenLabel.setFillColor(colSubtle);
+  m_fenLabel.setString("FEN (optional)");
+  m_fenLabel.setPosition(snapf(loadX), snapf(loadTop + 28.f));
+
+  const float fenW = loadWidth;
+  const float fenH = 22.f;
+  const float fenY = loadTop + 48.f;
 
   m_fenInputBox.setSize({fenW, fenH});
   m_fenInputBox.setFillColor(colInput);
   m_fenInputBox.setOutlineThickness(2.f);
   m_fenInputBox.setOutlineColor(colInputBorder);
-  m_fenInputBox.setPosition(snapf(fenX), snapf(fenY));
+  m_fenInputBox.setPosition(snapf(loadX), snapf(fenY));
 
   m_fenInputText.setFont(m_font);
   m_fenInputText.setCharacterSize(15);
   m_fenInputText.setFillColor(colText);
   m_fenInputText.setString(m_fenString);
   leftCenterText(m_fenInputText, m_fenInputBox.getGlobalBounds(), 8.f);
+
+  m_pgnLabel.setFont(m_font);
+  m_pgnLabel.setCharacterSize(14);
+  m_pgnLabel.setFillColor(colSubtle);
+  m_pgnLabel.setString("PGN (optional)");
+  const float pgnLabelY = fenY + fenH + 18.f;
+  m_pgnLabel.setPosition(snapf(loadX), snapf(pgnLabelY));
+
+  const float pgnH = 108.f;
+  const float pgnY = pgnLabelY + 18.f;
+  m_pgnInputBox.setSize({loadWidth, pgnH});
+  m_pgnInputBox.setFillColor(colInput);
+  m_pgnInputBox.setOutlineThickness(2.f);
+  m_pgnInputBox.setOutlineColor(colInputBorder);
+  m_pgnInputBox.setPosition(snapf(loadX), snapf(pgnY));
+
+  m_pgnInputText.setFont(m_font);
+  m_pgnInputText.setCharacterSize(15);
+  m_pgnInputText.setFillColor(colText);
+  m_pgnInputText.setString("");
+
+  m_pgnStatusText.setFont(m_font);
+  m_pgnStatusText.setCharacterSize(14);
+  m_pgnStatusText.setFillColor(colSubtle);
+  m_pgnStatusText.setString("");
+  m_pgnStatusText.setPosition(snapf(loadX), snapf(pgnY + pgnH + 8.f));
 
   // Build bot option lists
   auto bots = availableBots();
@@ -417,6 +403,59 @@ void StartScreen::setupUI() {
   m_timeTitle.setFillColor(colSubtle);
   m_timeTitle.setString("Time Control");
   m_timeTitle.setPosition(snap({timeX + 10.f, timeY + 8.f}));
+
+  // Warning popup (inactive by default)
+  sf::Vector2u ws = m_window.getSize();
+  m_warningBackdrop.setSize(sf::Vector2f(static_cast<float>(ws.x), static_cast<float>(ws.y)));
+  m_warningBackdrop.setFillColor(sf::Color(0, 0, 0, 120));
+
+  const sf::Vector2f warnSize(420.f, 220.f);
+  m_warningPanel.setSize(warnSize);
+  m_warningPanel.setFillColor(ColorPaletteManager::get().palette().COL_PANEL);
+  m_warningPanel.setOutlineThickness(1.f);
+  m_warningPanel.setOutlineColor(colPanelBorder);
+  m_warningPanel.setPosition(snapf((ws.x - warnSize.x) * 0.5f), snapf((ws.y - warnSize.y) * 0.5f));
+
+  m_warningTitle.setFont(m_font);
+  m_warningTitle.setCharacterSize(20);
+  m_warningTitle.setFillColor(colText);
+  m_warningTitle.setString("Invalid Load Data");
+  auto warnPos = m_warningPanel.getPosition();
+  m_warningTitle.setPosition(snapf(warnPos.x + 24.f), snapf(warnPos.y + 22.f));
+
+  m_warningMessage.setFont(m_font);
+  m_warningMessage.setCharacterSize(16);
+  m_warningMessage.setFillColor(colSubtle);
+  m_warningMessage.setString("");
+  m_warningMessage.setPosition(snapf(warnPos.x + 24.f), snapf(warnPos.y + 64.f));
+
+  const sf::Vector2f btnSize(140.f, 40.f);
+  const float btnSpacing = 24.f;
+  float btnTotal = btnSize.x * 2.f + btnSpacing;
+  float btnStartX = warnPos.x + (warnSize.x - btnTotal) * 0.5f;
+  float btnY = warnPos.y + warnSize.y - btnSize.y - 24.f;
+
+  m_warningCancelBtn.setSize(btnSize);
+  m_warningCancelBtn.setPosition(snapf(btnStartX), snapf(btnY));
+  m_warningCancelBtn.setFillColor(colButton);
+  m_warningCancelBtn.setOutlineThickness(0.f);
+
+  m_warningProceedBtn.setSize(btnSize);
+  m_warningProceedBtn.setPosition(snapf(btnStartX + btnSize.x + btnSpacing), snapf(btnY));
+  m_warningProceedBtn.setFillColor(colAccent);
+  m_warningProceedBtn.setOutlineThickness(0.f);
+
+  m_warningCancelText.setFont(m_font);
+  m_warningCancelText.setCharacterSize(16);
+  m_warningCancelText.setFillColor(colText);
+  m_warningCancelText.setString("Cancel");
+  centerText(m_warningCancelText, m_warningCancelBtn.getGlobalBounds());
+
+  m_warningProceedText.setFont(m_font);
+  m_warningProceedText.setCharacterSize(16);
+  m_warningProceedText.setFillColor(constant::COL_DARK_TEXT);
+  m_warningProceedText.setString("Proceed");
+  centerText(m_warningProceedText, m_warningProceedBtn.getGlobalBounds());
 
   m_timeMain.setFont(m_font);
   m_timeMain.setCharacterSize(22);
@@ -547,6 +586,13 @@ void StartScreen::applyTheme() {
   m_fenInputBox.setFillColor(colInput);
   m_fenInputBox.setOutlineColor(colInputBorder);
   m_fenInputText.setFillColor(colText);
+  m_loadHeader.setFillColor(colText);
+  m_fenLabel.setFillColor(colSubtle);
+  m_pgnLabel.setFillColor(colSubtle);
+  m_pgnStatusText.setFillColor(colSubtle);
+  m_pgnInputBox.setFillColor(colInput);
+  m_pgnInputBox.setOutlineColor(colInputBorder);
+  m_pgnInputText.setFillColor(colText);
 
   for (auto& opt : m_whiteBotOptions) {
     opt.box.setFillColor(colButton);
@@ -574,6 +620,15 @@ void StartScreen::applyTheme() {
     c.box.setFillColor(colButton);
     c.label.setFillColor(colText);
   }
+
+  m_warningPanel.setFillColor(ColorPaletteManager::get().palette().COL_PANEL);
+  m_warningPanel.setOutlineColor(colPanelBorder);
+  m_warningTitle.setFillColor(colText);
+  m_warningMessage.setFillColor(colSubtle);
+  m_warningCancelBtn.setFillColor(colButton);
+  m_warningProceedBtn.setFillColor(colAccent);
+  m_warningCancelText.setFillColor(colText);
+  m_warningProceedText.setFillColor(constant::COL_DARK_TEXT);
 
   updateTimeToggle();
 }
@@ -702,7 +757,17 @@ bool StartScreen::handleFenMouse(sf::Vector2f pos, StartConfig& cfg) {
 }
 
 bool StartScreen::isValidFen(const std::string& fen) {
-  return basicFenCheck(fen);
+  return model::fen::is_basic_fen_valid(fen);
+}
+
+void StartScreen::updateWarningMessage() {
+  std::string msg;
+  if (m_warnFenInvalid)
+    msg += "• FEN is invalid. The standard starting position will be used.\n";
+  if (m_warnPgnInvalid)
+    msg += "• PGN is invalid. No PGN will be loaded.\n";
+  if (msg.empty()) msg = "All load data is valid.";
+  m_warningMessage.setString(msg);
 }
 
 void StartScreen::processHoldRepeater(HoldRepeater& r, const sf::FloatRect& bounds,
@@ -730,22 +795,174 @@ StartConfig StartScreen::run() {
   cfg.timeIncrementSeconds = m_incrementSeconds;
   cfg.timeEnabled = m_timeEnabled;
 
-  // FEN field state
   bool fenInputActive = false;
   bool fenUserEdited = false;
-  const float fenPadX = 8.f;
+  bool pgnInputActive = false;
 
-  // Toast
+  const float fenPadX = 8.f;
+  const float pgnPadX = 8.f;
+  const float pgnPadY = 6.f;
+
   bool toastVisible = false;
   sf::Clock toastClock;
   std::string toastMsg;
-  // Caret blink
+
   sf::Clock caretClock;
+
+  std::optional<model::pgn::ParsedPgn> parsedPgn;
+  std::string pgnError;
+  bool pgnDirty = true;
+
+  auto recomputePgn = [&]() {
+    if (m_pgnString.empty()) {
+      parsedPgn.reset();
+      pgnError.clear();
+      return;
+    }
+    parsedPgn = model::pgn::parse(m_pgnString, &pgnError);
+    if (!parsedPgn) {
+      if (pgnError.empty()) pgnError = "PGN is invalid.";
+    } else {
+      pgnError.clear();
+    }
+  };
+
+  auto refreshPgn = [&]() {
+    if (pgnDirty) {
+      recomputePgn();
+      pgnDirty = false;
+    }
+  };
+
+  auto computeCurrentConfig = [&](bool applyDefaults) {
+    refreshPgn();
+    StartConfig out = cfg;
+    out.timeBaseSeconds = m_baseSeconds;
+    out.timeIncrementSeconds = m_incrementSeconds;
+    out.timeEnabled = m_timeEnabled;
+
+    std::string trimmedFen = trimCopy(m_fenString);
+    bool fenProvided = !trimmedFen.empty();
+    bool fenValid = trimmedFen.empty() || isValidFen(trimmedFen);
+
+    bool pgnProvided = !m_pgnString.empty();
+    bool pgnValid = parsedPgn.has_value();
+
+    if (applyDefaults) {
+      if (m_warnFenInvalid) {
+        m_fenString.clear();
+        trimmedFen.clear();
+        fenProvided = false;
+        fenValid = true;
+        fenUserEdited = false;
+      }
+      if (m_warnPgnInvalid) {
+        m_pgnString.clear();
+        parsedPgn.reset();
+        pgnError.clear();
+        pgnProvided = false;
+        pgnValid = false;
+        pgnDirty = false;
+      }
+    }
+
+    if (pgnProvided && pgnValid) {
+      out.loadFromPgn = true;
+      out.pgn = parsedPgn->sanitized;
+      out.fen = parsedPgn->finalFen;
+    } else {
+      out.loadFromPgn = false;
+      out.pgn.clear();
+      if (fenProvided && fenValid)
+        out.fen = trimmedFen;
+      else
+        out.fen = core::START_FEN;
+    }
+    return out;
+  };
+
+  struct WarningState {
+    bool fen{false};
+    bool pgn{false};
+  };
+
+  auto gatherWarnings = [&]() -> WarningState {
+    refreshPgn();
+    std::string trimmedFen = trimCopy(m_fenString);
+    bool fenProvided = !trimmedFen.empty();
+    bool fenValid = trimmedFen.empty() || isValidFen(trimmedFen);
+    bool pgnProvided = !m_pgnString.empty();
+    bool pgnValid = parsedPgn.has_value();
+    WarningState ws;
+    ws.fen = fenProvided && !fenValid;
+    ws.pgn = pgnProvided && !pgnValid;
+    return ws;
+  };
+
+  auto attemptStart = [&]() -> std::optional<StartConfig> {
+    WarningState ws = gatherWarnings();
+    if (ws.fen || ws.pgn) {
+      m_warnFenInvalid = ws.fen;
+      m_warnPgnInvalid = ws.pgn;
+      m_showLoadWarning = true;
+      updateWarningMessage();
+      return std::nullopt;
+    }
+    return computeCurrentConfig(false);
+  };
+
+  auto wrapPgnText = [&](const std::string& text) {
+    std::vector<std::string> lines;
+    std::string current;
+    std::string word;
+    const float maxWidth = m_pgnInputBox.getSize().x - 2.f * pgnPadX;
+
+    auto pushWord = [&](const std::string& w) {
+      if (w.empty()) return;
+      std::string candidate = current.empty() ? w : current + " " + w;
+      sf::Text probe(candidate, m_font, 15);
+      if (probe.getLocalBounds().width <= maxWidth) {
+        current = candidate;
+      } else {
+        if (!current.empty()) lines.push_back(current);
+        current = w;
+      }
+    };
+
+    for (char c : text) {
+      if (c == '\r') continue;
+      if (c == '\n') {
+        if (!word.empty()) {
+          pushWord(word);
+          word.clear();
+        }
+        if (!current.empty()) {
+          lines.push_back(current);
+          current.clear();
+        } else {
+          lines.emplace_back();
+        }
+        continue;
+      }
+      if (std::isspace(static_cast<unsigned char>(c))) {
+        pushWord(word);
+        word.clear();
+      } else {
+        word.push_back(c);
+      }
+    }
+    if (!word.empty()) {
+      pushWord(word);
+      word.clear();
+    }
+    if (!current.empty()) lines.push_back(current);
+    if (lines.empty()) lines.emplace_back();
+    return lines;
+  };
 
   auto drawUI = [&]() {
     drawVerticalGradient(m_window, colBGTop, colBGBottom);
 
-    // palette selector
     bool palHover = contains(m_paletteButton.getGlobalBounds(), m_mousePos) || m_showPaletteList ||
                     m_paletteListAnim > 0.f;
     m_paletteButton.setFillColor(palHover ? colButtonActive : colButton);
@@ -775,7 +992,6 @@ StartConfig StartScreen::run() {
       }
     }
 
-    // faint logo
     if (m_logoTex.getSize().x > 0 && m_logoTex.getSize().y > 0) {
       sf::Sprite logoBG(m_logoTex);
       const auto ws = m_window.getSize();
@@ -789,12 +1005,10 @@ StartConfig StartScreen::run() {
       m_window.draw(logoBG, sf::RenderStates(sf::BlendAlpha));
     }
 
-    // main panel
     sf::Vector2f panelPos((m_window.getSize().x - PANEL_W) * 0.5f,
                           (m_window.getSize().y - PANEL_H) * 0.5f);
     drawPanelWithShadow(m_window, panelPos);
 
-    // header
     sf::Text title("Lilia Engine - Bot Sandbox", m_font, 28);
     title.setFillColor(colText);
     title.setPosition(snapf(panelPos.x + 24.f), snapf(panelPos.y + 18.f));
@@ -805,11 +1019,9 @@ StartConfig StartScreen::run() {
     subtitle.setPosition(snapf(panelPos.x + 24.f), snapf(panelPos.y + 52.f));
     m_window.draw(subtitle);
 
-    // Sections
     m_window.draw(m_whiteLabel);
     m_window.draw(m_blackLabel);
 
-    // White column
     {
       auto humanR = m_whitePlayerBtn.getGlobalBounds();
       auto botR = m_whiteBotBtn.getGlobalBounds();
@@ -826,7 +1038,6 @@ StartConfig StartScreen::run() {
       if (selB) drawAccentInset(m_window, botR, colAccent);
     }
 
-    // Black column
     {
       auto humanR = m_blackPlayerBtn.getGlobalBounds();
       auto botR = m_blackBotBtn.getGlobalBounds();
@@ -843,7 +1054,6 @@ StartConfig StartScreen::run() {
       if (selB) drawAccentInset(m_window, botR, colAccent);
     }
 
-    // Bot dropdowns
     auto drawBotList = [&](const std::vector<BotOption>& list, std::size_t selIdx, float anim) {
       for (std::size_t i = 0; i < list.size(); ++i) {
         const auto& opt = list[i];
@@ -869,7 +1079,6 @@ StartConfig StartScreen::run() {
     if (m_whiteBotListAnim > 0.f) drawBotList(m_whiteBotOptions, m_whiteBotSelection, m_whiteBotListAnim);
     if (m_blackBotListAnim > 0.f) drawBotList(m_blackBotOptions, m_blackBotSelection, m_blackBotListAnim);
 
-    // Time toggle
     {
       auto gb = m_timeToggleBtn.getGlobalBounds();
       bool hov = contains(gb, m_mousePos);
@@ -880,11 +1089,9 @@ StartConfig StartScreen::run() {
       m_window.draw(m_timeToggleText);
     }
 
-    // Time panel (no shadow)
     if (m_timeEnabled) {
       auto gb = m_timePanel.getGlobalBounds();
       m_window.draw(m_timePanel);
-      // simple inner lines (not shadows)
       sf::RectangleShape top({gb.width, 1.f});
       top.setPosition(gb.left, gb.top);
       top.setFillColor(ColorPaletteManager::get().palette().COL_TOP_HILIGHT);
@@ -925,25 +1132,28 @@ StartConfig StartScreen::run() {
       }
     }
 
-    const bool fenEmpty = m_fenString.empty();
-    const bool fenValid = (!fenEmpty) && isValidFen(m_fenString);
+    refreshPgn();
+    std::string trimmedFen = trimCopy(m_fenString);
+    bool fenEmpty = trimmedFen.empty();
+    bool fenValid = trimmedFen.empty() || isValidFen(trimmedFen);
+    bool pgnEmpty = m_pgnString.empty();
+    bool pgnValid = !pgnEmpty && parsedPgn.has_value();
 
-    // Start (beveled)
-    {
-      auto r = m_startBtn.getGlobalBounds();
-      bool hov = contains(r, m_mousePos);
-      drawBevelButton3D(m_window, r, colAccent, hov, false);
-      centerText(m_startText, r);
-      m_window.draw(m_startText);
-      if (!fenEmpty && !fenValid) m_window.draw(m_fenErrorText);
+    m_window.draw(m_loadHeader);
+    m_window.draw(m_fenLabel);
+    m_window.draw(m_pgnLabel);
+
+    if (!fenEmpty && !fenValid) {
+      m_fenErrorText.setString("INVALID FEN - DEFAULT WILL BE USED");
+      m_window.draw(m_fenErrorText);
+    } else {
+      m_fenErrorText.setString("STANDARD FEN");
     }
 
-    // -------- FEN field --------
     m_fenInputBox.setOutlineColor(fenEmpty ? colInputBorder : (fenValid ? colValid : colInvalid));
     m_window.draw(m_fenInputBox);
 
-    // Text or placeholder
-    if (fenEmpty) {
+    if (m_fenString.empty()) {
       sf::Text placeholder("STANDARD FEN", m_font, 15);
       placeholder.setFillColor(colSubtle);
       leftCenterText(placeholder, m_fenInputBox.getGlobalBounds(), fenPadX);
@@ -954,27 +1164,90 @@ StartConfig StartScreen::run() {
       m_window.draw(m_fenInputText);
     }
 
-    // Blinking caret when focused
     if (fenInputActive) {
       float t = std::fmod(caretClock.getElapsedTime().asSeconds(), 1.0f);
       if (t < 0.5f) {
-        // caret position = end of current text
         sf::Text probe(m_fenString, m_font, 15);
         auto b = probe.getLocalBounds();
         float left = m_fenInputBox.getPosition().x + fenPadX;
-        float top = m_fenInputBox.getPosition().y;
-        float h = m_fenInputBox.getSize().y;
         float caretX = left + b.width + 1.f;
         float maxX = m_fenInputBox.getPosition().x + m_fenInputBox.getSize().x - 2.f;
         caretX = std::min(caretX, maxX - 1.f);
-        sf::RectangleShape caret({2.f, h * 0.65f});
-        caret.setPosition(snapf(caretX), snapf(top + (h - caret.getSize().y) * 0.5f));
+        float caretHeight = b.height;
+        if (caretHeight <= 0.f) caretHeight = m_font.getLineSpacing(15) * 0.8f;
+        float caretY = m_fenInputBox.getPosition().y + (m_fenInputBox.getSize().y - caretHeight) * 0.5f - b.top;
+        sf::RectangleShape caret({2.f, caretHeight});
+        caret.setPosition(snapf(caretX), snapf(caretY));
         caret.setFillColor(colText);
         m_window.draw(caret);
       }
     }
 
-    // Toast (bottom center)
+    m_pgnInputBox.setOutlineColor(pgnEmpty ? colInputBorder : (pgnValid ? colValid : colInvalid));
+    m_window.draw(m_pgnInputBox);
+
+    if (pgnEmpty) {
+      sf::Text placeholder("Paste PGN (SAN moves)", m_font, 15);
+      placeholder.setFillColor(colSubtle);
+      auto lb = placeholder.getLocalBounds();
+      placeholder.setPosition(snapf(m_pgnInputBox.getPosition().x + pgnPadX - lb.left),
+                              snapf(m_pgnInputBox.getPosition().y + pgnPadY - lb.top));
+      m_window.draw(placeholder);
+    }
+
+    auto lines = wrapPgnText(m_pgnString);
+    sf::Text lineText("", m_font, 15);
+    lineText.setFillColor(colText);
+    float lineSpacing = m_font.getLineSpacing(15);
+    float baseX = m_pgnInputBox.getPosition().x + pgnPadX;
+    float baseY = m_pgnInputBox.getPosition().y + pgnPadY;
+    for (std::size_t i = 0; i < lines.size(); ++i) {
+      const std::string& line = lines[i];
+      if (line.empty() && pgnEmpty) continue;
+      lineText.setString(line);
+      auto lb = lineText.getLocalBounds();
+      lineText.setPosition(snapf(baseX - lb.left), snapf(baseY + i * lineSpacing - lb.top));
+      m_window.draw(lineText);
+    }
+
+    if (pgnInputActive) {
+      float t = std::fmod(caretClock.getElapsedTime().asSeconds(), 1.0f);
+      if (t < 0.5f) {
+        std::string lastLine = lines.empty() ? std::string{} : lines.back();
+        sf::Text probe(lastLine, m_font, 15);
+        auto lb = probe.getLocalBounds();
+        float caretHeight = lb.height;
+        if (caretHeight <= 0.f) caretHeight = m_font.getLineSpacing(15) * 0.8f;
+        float caretX = baseX + lb.width + 1.f;
+        float maxX = m_pgnInputBox.getPosition().x + m_pgnInputBox.getSize().x - pgnPadX - 1.f;
+        caretX = std::min(caretX, maxX);
+        float caretY = baseY + (lines.size() - 1) * lineSpacing - lb.top;
+        sf::RectangleShape caret({2.f, caretHeight});
+        caret.setPosition(snapf(caretX), snapf(caretY));
+        caret.setFillColor(colText);
+        m_window.draw(caret);
+      }
+    }
+
+    if (pgnEmpty) {
+      m_pgnStatusText.setString("Paste PGN (SAN) to load a game.");
+      m_pgnStatusText.setFillColor(colSubtle);
+    } else if (pgnValid) {
+      m_pgnStatusText.setString("PGN is valid. Final position will be used.");
+      m_pgnStatusText.setFillColor(colValid);
+    } else {
+      std::string msg = pgnError.empty() ? "PGN is invalid." : pgnError;
+      m_pgnStatusText.setString(msg);
+      m_pgnStatusText.setFillColor(colInvalid);
+    }
+    m_window.draw(m_pgnStatusText);
+
+    auto startBounds = m_startBtn.getGlobalBounds();
+    bool hovStart = contains(startBounds, m_mousePos);
+    drawBevelButton3D(m_window, startBounds, colAccent, hovStart, false);
+    centerText(m_startText, startBounds);
+    m_window.draw(m_startText);
+
     if (toastVisible) {
       float elapsed = toastClock.getElapsedTime().asSeconds();
       if (elapsed < 2.2f) {
@@ -1000,7 +1273,6 @@ StartConfig StartScreen::run() {
       }
     }
 
-    // Developer credit (bottom right)
     {
       sf::Text credit("@ 2025 Julian Meyer", m_font, 13);
       credit.setFillColor(colSubtle);
@@ -1010,9 +1282,27 @@ StartConfig StartScreen::run() {
                          snapf((float)ws.y - cb.height - 22.f));
       m_window.draw(credit);
     }
+
+    if (m_showLoadWarning) {
+      m_window.draw(m_warningBackdrop);
+      m_window.draw(m_warningPanel);
+      m_window.draw(m_warningTitle);
+      m_window.draw(m_warningMessage);
+
+      auto cancelBounds = m_warningCancelBtn.getGlobalBounds();
+      bool cancelHover = contains(cancelBounds, m_mousePos);
+      drawBevelButton3D(m_window, cancelBounds, colButton, cancelHover, false);
+      centerText(m_warningCancelText, cancelBounds);
+      m_window.draw(m_warningCancelText);
+
+      auto proceedBounds = m_warningProceedBtn.getGlobalBounds();
+      bool proceedHover = contains(proceedBounds, m_mousePos);
+      drawBevelButton3D(m_window, proceedBounds, colAccent, proceedHover, false);
+      centerText(m_warningProceedText, proceedBounds);
+      m_window.draw(m_warningProceedText);
+    }
   };
 
-  // Loop
   sf::Clock frameClock;
   while (m_window.isOpen()) {
     float dt = frameClock.restart().asSeconds();
@@ -1025,6 +1315,38 @@ StartConfig StartScreen::run() {
       if (e.type == sf::Event::Resized) {
         setupUI();
       }
+
+      if (m_showLoadWarning) {
+        if (e.type == sf::Event::MouseMoved) {
+          m_mousePos = {(float)e.mouseMove.x, (float)e.mouseMove.y};
+        } else if (e.type == sf::Event::MouseButtonPressed &&
+                   e.mouseButton.button == sf::Mouse::Left) {
+          sf::Vector2f mp((float)e.mouseButton.x, (float)e.mouseButton.y);
+          if (contains(m_warningCancelBtn.getGlobalBounds(), mp)) {
+            m_showLoadWarning = false;
+            m_warnFenInvalid = m_warnPgnInvalid = false;
+          } else if (contains(m_warningProceedBtn.getGlobalBounds(), mp)) {
+            StartConfig out = computeCurrentConfig(true);
+            m_showLoadWarning = false;
+            m_warnFenInvalid = m_warnPgnInvalid = false;
+            pgnDirty = true;
+            return out;
+          }
+        } else if (e.type == sf::Event::KeyPressed) {
+          if (e.key.code == sf::Keyboard::Escape) {
+            m_showLoadWarning = false;
+            m_warnFenInvalid = m_warnPgnInvalid = false;
+          } else if (e.key.code == sf::Keyboard::Enter) {
+            StartConfig out = computeCurrentConfig(true);
+            m_showLoadWarning = false;
+            m_warnFenInvalid = m_warnPgnInvalid = false;
+            pgnDirty = true;
+            return out;
+          }
+        }
+        continue;
+      }
+
       if (e.type == sf::Event::MouseMoved) {
         m_mousePos = {(float)e.mouseMove.x, (float)e.mouseMove.y};
         auto updateHover = [&](bool& show, bool& forceHide, const sf::FloatRect& btn,
@@ -1048,7 +1370,6 @@ StartConfig StartScreen::run() {
                     m_blackBotOptions);
       }
 
-      // Keyboard
       if (e.type == sf::Event::KeyPressed) {
         if (m_timeEnabled && e.key.code == sf::Keyboard::Left) {
           m_baseSeconds = clampBaseSeconds(m_baseSeconds - (e.key.shift ? 300 : 60));
@@ -1062,30 +1383,14 @@ StartConfig StartScreen::run() {
         } else if (m_timeEnabled && e.key.code == sf::Keyboard::Up) {
           m_incrementSeconds = clampIncSeconds(m_incrementSeconds + 1);
           m_incValue.setString("+" + std::to_string(m_incrementSeconds) + "s");
-        } else if (e.key.code == sf::Keyboard::Enter) {
-          // Start game
-          cfg.timeBaseSeconds = m_baseSeconds;
-          cfg.timeIncrementSeconds = m_incrementSeconds;
-          cfg.timeEnabled = m_timeEnabled;
-          if (m_fenString.empty() || !isValidFen(m_fenString)) {
-            if (!m_fenString.empty()) {
-              toastMsg = "INCORRECT. STANDARD WILL BE CHOSEN";
-              toastVisible = true;
-              toastClock.restart();
-            }
-            cfg.fen = core::START_FEN;
-          } else {
-            cfg.fen = m_fenString;
-          }
-          return cfg;
+        } else if (e.key.code == sf::Keyboard::Enter && !pgnInputActive) {
+          if (auto out = attemptStart()) return *out;
         }
       }
 
-      // Mouse press
       if (e.type == sf::Event::MouseButtonPressed && e.mouseButton.button == sf::Mouse::Left) {
         sf::Vector2f mp((float)e.mouseButton.x, (float)e.mouseButton.y);
 
-        // steppers
         if (m_timeEnabled && contains(m_timeMinusBtn.getGlobalBounds(), mp)) {
           m_baseSeconds = clampBaseSeconds(m_baseSeconds - 60);
           m_timeMain.setString(formatHMS(m_baseSeconds));
@@ -1113,36 +1418,27 @@ StartConfig StartScreen::run() {
         } else if (contains(m_timeToggleBtn.getGlobalBounds(), mp)) {
           m_timeEnabled = !m_timeEnabled;
           updateTimeToggle();
-          m_holdBaseMinus.active = m_holdBasePlus.active = m_holdIncMinus.active =
-              m_holdIncPlus.active = false;
         } else if (contains(m_fenInputBox.getGlobalBounds(), mp)) {
           fenInputActive = true;
+          pgnInputActive = false;
+          caretClock.restart();
+        } else if (contains(m_pgnInputBox.getGlobalBounds(), mp)) {
+          pgnInputActive = true;
+          fenInputActive = false;
           caretClock.restart();
         } else {
-          // Blurring FEN: show toast if user edited & invalid (and not empty)
           if (fenInputActive) {
             fenInputActive = false;
             if (fenUserEdited && !m_fenString.empty() && !isValidFen(m_fenString)) {
-              toastMsg = "INCORRECT. STANDARD WILL BE CHOSEN";
+              toastMsg = "Incorrect FEN. Default will be used.";
               toastVisible = true;
               toastClock.restart();
             }
           }
-          // delegate (sides/presets/start)
+          if (pgnInputActive) pgnInputActive = false;
+
           if (handleMouse(mp, cfg)) {
-            cfg.timeBaseSeconds = m_baseSeconds;
-            cfg.timeIncrementSeconds = m_incrementSeconds;
-            cfg.timeEnabled = m_timeEnabled;
-            if (m_fenString.empty() || !isValidFen(m_fenString)) {
-              if (!m_fenString.empty()) {
-                toastMsg = "INCORRECT. STANDARD WILL BE CHOSEN";
-                toastVisible = true;
-                toastClock.restart();
-              }
-              cfg.fen = core::START_FEN;
-            } else
-              cfg.fen = m_fenString;
-            return cfg;
+            if (auto out = attemptStart()) return *out;
           }
         }
       }
@@ -1152,13 +1448,11 @@ StartConfig StartScreen::run() {
             m_holdIncPlus.active = false;
       }
 
-      // Paste to FEN (fit to width; no overflow)
       if (fenInputActive && e.type == sf::Event::KeyPressed && (e.key.control || e.key.system) &&
           e.key.code == sf::Keyboard::V) {
         auto clip = sf::Clipboard::getString().toAnsiString();
         clip.erase(std::remove(clip.begin(), clip.end(), '\n'), clip.end());
         clip.erase(std::remove(clip.begin(), clip.end(), '\r'), clip.end());
-        // append only while it fits
         const float avail = m_fenInputBox.getSize().x - 2.f * fenPadX - 2.f;
         std::string out = m_fenString;
         for (char c : clip) {
@@ -1172,12 +1466,10 @@ StartConfig StartScreen::run() {
           m_fenString = out;
           fenUserEdited = true;
         }
-        m_fenInputText.setString(m_fenString);
       }
 
-      // Typing into FEN (no overflow)
       if (fenInputActive && e.type == sf::Event::TextEntered) {
-        if (e.text.unicode == 8) {  // backspace
+        if (e.text.unicode == 8) {
           if (!m_fenString.empty()) {
             m_fenString.pop_back();
             fenUserEdited = true;
@@ -1192,11 +1484,36 @@ StartConfig StartScreen::run() {
             fenUserEdited = true;
           }
         }
-        m_fenInputText.setString(m_fenString);
+      }
+
+      if (pgnInputActive && e.type == sf::Event::KeyPressed && (e.key.control || e.key.system) &&
+          e.key.code == sf::Keyboard::V) {
+        auto clip = sf::Clipboard::getString().toAnsiString();
+        for (char c : clip) {
+          if (c == '\r') continue;
+          if (c >= 32 || c == '\n') m_pgnString.push_back(c);
+        }
+        pgnDirty = true;
+      }
+
+      if (pgnInputActive && e.type == sf::Event::TextEntered) {
+        if (e.text.unicode == 8) {
+          if (!m_pgnString.empty()) {
+            m_pgnString.pop_back();
+            pgnDirty = true;
+          }
+        } else if (e.text.unicode == 13) {
+          // ignore carriage return
+        } else if (e.text.unicode == 10) {
+          m_pgnString.push_back('\n');
+          pgnDirty = true;
+        } else if (e.text.unicode >= 32 && e.text.unicode < 127) {
+          m_pgnString.push_back((char)e.text.unicode);
+          pgnDirty = true;
+        }
       }
     }
 
-    // hold-repeat ticks
     if (m_timeEnabled) {
       processHoldRepeater(m_holdBaseMinus, m_timeMinusBtn.getGlobalBounds(), m_mousePos, [&] {
         m_baseSeconds = clampBaseSeconds(m_baseSeconds - 60);
@@ -1227,20 +1544,12 @@ StartConfig StartScreen::run() {
     animateList(m_showWhiteBotList, m_whiteBotListAnim);
     animateList(m_showBlackBotList, m_blackBotListAnim);
 
-    // draw
     m_window.clear();
     drawUI();
     m_window.display();
   }
 
-  cfg.timeBaseSeconds = m_baseSeconds;
-  cfg.timeIncrementSeconds = m_incrementSeconds;
-  cfg.timeEnabled = m_timeEnabled;
-  if (m_fenString.empty() || !isValidFen(m_fenString))
-    cfg.fen = core::START_FEN;
-  else
-    cfg.fen = m_fenString;
-  return cfg;
+  return computeCurrentConfig(false);
 }
 
 }  // namespace lilia::view


### PR DESCRIPTION
## Summary
- add shared FEN validator and PGN parser to reuse for validating load inputs
- extend the start screen UI to accept PGN text, show validation state, and update StartConfig when PGN wins over FEN
- add a warning dialog that offers default fallbacks for invalid FEN/PGN values and tweak caret rendering

## Testing
- cmake -S . -B build -DLILIA_BUILD_UI=ON *(fails: missing OpenGL libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68d55b430fe483299faba964eb0b8ce7