### PR TITLE
Handle discovered checks in quiet move heuristics

### DIFF
--- a/tests/tactical_quiet_test.cpp
+++ b/tests/tactical_quiet_test.cpp
@@ -40,6 +40,19 @@ int main() {
     assert(*res.bestMove == expected);
   }
 
+  // Quiet discovered check after clearance (rook gives the check)
+  {
+    model::ChessGame game;
+    game.setPosition("4k3/8/8/8/8/8/4N3/4R1K1 w - - 0 1");
+    auto res = bot.findBestMove(game, 2, 10);
+    assert(res.bestMove);
+
+    model::Position posCopy = game.getPositionRefForBot();
+    bool applied = posCopy.doMove(*res.bestMove);
+    assert(applied);
+    assert(posCopy.inCheck());
+  }
+
   // Best move should match the first entry in topMoves even when TT suggests a different move
   {
     model::ChessGame game;


### PR DESCRIPTION
## Summary
- compute post-move attack information so would_give_check_after sees discovered checks, including en passant and castling occupancy updates
- reuse the same logic inside quiet_piece_threat_signal so quiet moves that reveal attacks still register as checks
- cover a discovered-check FEN with a regression test to ensure the engine preserves the sacrificial checking line

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build
- ./build/engine_tests

------
https://chatgpt.com/codex/tasks/task_e_68d674de2fc88329900f0460496145a5