### PR TITLE
Add start screen load game modal with PGN import

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -29,6 +30,7 @@ class ChessGame;
 struct Move;
 class Position;
 class MoveGenerator;
+struct PgnImport;
 namespace bb {
 struct Piece;
 }
@@ -90,7 +92,8 @@ public:
                  int whiteThinkTimeMs = 1000, int whiteDepth = 5,
                  int blackThinkTimeMs = 1000, int blackDepth = 5,
                  bool useTimer = true, int baseSeconds = 0,
-                 int incrementSeconds = 0);
+                 int incrementSeconds = 0,
+                 const std::optional<model::PgnImport> &pgnImport = std::nullopt);
 
   enum class NextAction { None, NewBot, Rematch };
   [[nodiscard]] NextAction getNextAction() const;
@@ -180,6 +183,7 @@ private:
   core::PieceType m_pending_capture_type = core::PieceType::None;
   core::PieceType m_pending_promotion = core::PieceType::None;
   bool m_skip_next_move_animation = false;
+  bool m_importingHistory = false;
 
   SelectionManager m_selection_manager;
 

--- a/include/lilia/controller/game_manager.hpp
+++ b/include/lilia/controller/game_manager.hpp
@@ -5,6 +5,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <string>
 
 #include "../chess_types.hpp"
 #include "../constants.hpp"
@@ -35,6 +36,9 @@ public:
                  int whiteThinkTimeMs = 1000, int whiteDepth = 5,
                  int blackThinkTimeMs = 1000, int blackDepth = 5);
   void stopGame();
+
+  bool applyImportedMove(const std::string &uciMove);
+  void resumeBotsAfterImport();
 
   void update(float dt);
 
@@ -79,6 +83,8 @@ private:
 
   void applyMoveAndNotify(const model::Move &mv, bool onClick);
   void startBotIfNeeded();
+
+  bool m_suspendBots{false};
 };
 
 } // namespace lilia::controller

--- a/include/lilia/model/fen_validator.hpp
+++ b/include/lilia/model/fen_validator.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+namespace lilia::model {
+
+bool isFenWellFormed(const std::string &fen);
+
+}  // namespace lilia::model

--- a/include/lilia/model/pgn_parser.hpp
+++ b/include/lilia/model/pgn_parser.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace lilia::model {
+
+struct PgnImport {
+  std::string startFen;
+  std::string finalFen;
+  std::vector<std::string> movesUci;
+  std::string termination;  // "1-0", "0-1", "1/2-1/2", "*" or empty
+};
+
+bool parsePgn(const std::string &pgnText, PgnImport &outImport, std::string *error = nullptr);
+
+}  // namespace lilia::model

--- a/include/lilia/view/start_screen.hpp
+++ b/include/lilia/view/start_screen.hpp
@@ -2,12 +2,15 @@
 
 #include <SFML/Graphics.hpp>
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "lilia/bot/bot_info.hpp"
 #include "lilia/constants.hpp"
+#include "lilia/model/pgn_parser.hpp"
 #include "lilia/view/color_palette_manager.hpp"
+#include "lilia/view/start_screen_dialogs.hpp"
 
 namespace lilia::view {
 
@@ -20,6 +23,7 @@ struct StartConfig {
   int timeBaseSeconds{300};     // default 5 minutes
   int timeIncrementSeconds{0};  // default 0s increment
   bool timeEnabled{true};       // whether clocks are used
+  std::optional<model::PgnImport> pgnImport;
 };
 
 struct BotOption {
@@ -45,8 +49,7 @@ class StartScreen {
   sf::Font m_font;
   sf::Texture m_logoTex;
   sf::Sprite m_logo;
-  sf::Text m_devByText;    // "@Developed by Julian Meyer" bottom-right
-  sf::Text m_fenInfoText;  // subtle hint below FEN box
+  sf::Text m_devByText;  // "@Developed by Julian Meyer" bottom-right
 
   sf::RectangleShape m_whitePlayerBtn;
   sf::RectangleShape m_whiteBotBtn;
@@ -73,6 +76,9 @@ class StartScreen {
   sf::RectangleShape m_startBtn;
   sf::Text m_startText;
   sf::Text m_creditText;
+  sf::RectangleShape m_loadGameBtn;
+  sf::Text m_loadGameText;
+  sf::Text m_loadSummaryText;
 
   // Palette selection UI
   sf::RectangleShape m_paletteButton;
@@ -83,19 +89,10 @@ class StartScreen {
   bool m_paletteListForceHide{false};
   float m_paletteListAnim{0.f};
 
-  // FEN popup UI
-  bool m_showFenPopup{false};
-  sf::RectangleShape m_fenPopup;
-  sf::RectangleShape m_fenInputBox;
-  sf::Text m_fenInputText;
-  sf::RectangleShape m_fenBackBtn;
-  sf::RectangleShape m_fenContinueBtn;
-  sf::Text m_fenBackText;
-  sf::Text m_fenContinueText;
-  sf::Text m_fenErrorText;
-  std::string m_fenString;
-  sf::Clock m_errorClock;
-  bool m_showError{false};
+  std::string m_fenInput;
+  std::string m_pgnInput;
+  LoadGameModal m_loadModal;
+  WarningDialog m_warningDialog;
 
   // time control state
   int m_baseSeconds{300};
@@ -137,8 +134,8 @@ class StartScreen {
   void setupUI();
   void applyTheme();
   bool handleMouse(sf::Vector2f pos, StartConfig &cfg);
-  bool handleFenMouse(sf::Vector2f pos, StartConfig &cfg);
-  bool isValidFen(const std::string &fen);
+  void updateLoadSummary();
+  bool validateFen(const std::string &fen) const;
   void updateTimeToggle();
   void processHoldRepeater(HoldRepeater &r, const sf::FloatRect &bounds, sf::Vector2f mouse,
                            std::function<void()> stepFn, float initialDelay = 0.35f,

--- a/include/lilia/view/start_screen_dialogs.hpp
+++ b/include/lilia/view/start_screen_dialogs.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+#include <string>
+
+namespace lilia::view {
+
+class LoadGameModal {
+ public:
+  explicit LoadGameModal(const sf::Font &font);
+
+  void open(const std::string &fen, const std::string &pgn);
+  void close();
+  [[nodiscard]] bool isOpen() const;
+
+  enum class EventResult { None, Closed };
+  EventResult handleEvent(const sf::Event &event, sf::Vector2f mousePos);
+
+  void draw(sf::RenderWindow &window);
+  void applyTheme();
+
+  [[nodiscard]] const std::string &getFen() const { return m_fenString; }
+  [[nodiscard]] const std::string &getPgn() const { return m_pgnString; }
+
+ private:
+  void layout(const sf::Vector2u &windowSize);
+  void refreshTexts();
+  void resetCaret();
+  void updateCaretVisibility();
+  bool handleTextEntered(sf::Uint32 unicode);
+  bool handleKeyPressed(const sf::Event::KeyEvent &key, bool ctrlDown);
+  void pasteFromClipboard();
+  void drawCaret(sf::RenderWindow &window) const;
+
+  const sf::Font &m_font;
+  bool m_visible{false};
+
+  sf::RectangleShape m_overlay;
+  sf::RectangleShape m_panel;
+  sf::Text m_title;
+  sf::Text m_fenLabel;
+  sf::RectangleShape m_fenBox;
+  sf::Text m_fenText;
+  sf::Text m_fenPlaceholder;
+  sf::Text m_pgnLabel;
+  sf::RectangleShape m_pgnBox;
+  sf::Text m_pgnText;
+  sf::Text m_pgnPlaceholder;
+  sf::RectangleShape m_closeButton;
+  sf::Text m_closeText;
+
+  std::string m_fenString;
+  std::string m_pgnString;
+
+  bool m_fenActive{false};
+  bool m_pgnActive{false};
+  mutable sf::Clock m_caretClock;
+  float m_fenCaretX{0.f};
+  float m_pgnCaretX{0.f};
+  float m_pgnCaretY{0.f};
+};
+
+class WarningDialog {
+ public:
+  explicit WarningDialog(const sf::Font &font);
+
+  void open(const std::string &message);
+  void close();
+  [[nodiscard]] bool isOpen() const;
+
+  enum class Choice { None, UseDefaults, Cancel };
+  Choice handleEvent(const sf::Event &event, sf::Vector2f mousePos);
+
+  void draw(sf::RenderWindow &window);
+  void applyTheme();
+
+ private:
+  void layout(const sf::Vector2u &windowSize);
+
+  const sf::Font &m_font;
+  bool m_visible{false};
+
+  sf::RectangleShape m_overlay;
+  sf::RectangleShape m_panel;
+  sf::Text m_message;
+  sf::RectangleShape m_acceptBtn;
+  sf::RectangleShape m_cancelBtn;
+  sf::Text m_acceptText;
+  sf::Text m_cancelText;
+};
+
+}  // namespace lilia::view

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -2,11 +2,13 @@
 
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Window/Event.hpp>
+#include <optional>
 
 #include "lilia/bot/bot_info.hpp"
 #include "lilia/controller/game_controller.hpp"
 #include "lilia/engine/engine.hpp"
 #include "lilia/model/chess_game.hpp"
+#include "lilia/model/pgn_parser.hpp"
 #include "lilia/view/game_view.hpp"
 #include "lilia/view/start_screen.hpp"
 #include "lilia/view/texture_table.hpp"
@@ -42,6 +44,7 @@ int App::run() {
     int baseSeconds = cfg.timeBaseSeconds;
     int incrementSeconds = cfg.timeIncrementSeconds;
     bool timeEnabled = cfg.timeEnabled;
+    std::optional<model::PgnImport> startImport = cfg.pgnImport;
 
     auto whiteCfg = getBotConfig(cfg.whiteBot);
     auto blackCfg = getBotConfig(cfg.blackBot);
@@ -61,7 +64,8 @@ int App::run() {
 
       gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot, whiteThinkMs,
                                whiteDepth, blackThinkMs, blackDepth, timeEnabled, baseSeconds,
-                               incrementSeconds);
+                               incrementSeconds, startImport);
+      startImport.reset();
 
       sf::Clock clock;
       while (window.isOpen() && gameController.getNextAction() ==

--- a/src/lilia/controller/game_manager.cpp
+++ b/src/lilia/controller/game_manager.cpp
@@ -1,10 +1,12 @@
 #include "lilia/controller/game_manager.hpp"
 
 #include <chrono>
+#include <cctype>
 
 #include "lilia/controller/bot_player.hpp"
 #include "lilia/controller/player.hpp"
 #include "lilia/model/chess_game.hpp"
+#include "lilia/uci/uci_helper.hpp"
 
 namespace lilia::controller {
 
@@ -21,6 +23,7 @@ void GameManager::startGame(const std::string &fen, bool whiteIsBot, bool blackI
   m_game.setPosition(fen);
   m_cancel_bot.store(false);
   m_waiting_promotion = false;
+  m_suspendBots = false;
 
   if (whiteIsBot)
     m_white_player = std::make_unique<BotPlayer>(whiteThinkTimeMs, whiteDepth);
@@ -38,6 +41,66 @@ void GameManager::startGame(const std::string &fen, bool whiteIsBot, bool blackI
 void GameManager::stopGame() {
   std::lock_guard lock(m_mutex);
   m_cancel_bot.store(true);
+}
+
+namespace {
+core::Square parseSquare(char file, char rank) {
+  if (file < 'a' || file > 'h') return core::NO_SQUARE;
+  if (rank < '1' || rank > '8') return core::NO_SQUARE;
+  const int f = file - 'a';
+  const int r = rank - '1';
+  return static_cast<core::Square>(f + r * 8);
+}
+
+core::PieceType promotionFromChar(char c) {
+  switch (static_cast<char>(std::tolower(static_cast<unsigned char>(c)))) {
+    case 'q':
+      return core::PieceType::Queen;
+    case 'r':
+      return core::PieceType::Rook;
+    case 'b':
+      return core::PieceType::Bishop;
+    case 'n':
+      return core::PieceType::Knight;
+    default:
+      return core::PieceType::None;
+  }
+}
+}  // namespace
+
+bool GameManager::applyImportedMove(const std::string &uciMove) {
+  std::lock_guard lock(m_mutex);
+  if (uciMove.size() < 4) return false;
+
+  m_cancel_bot.store(true);
+  m_suspendBots = true;
+
+  core::Square from = parseSquare(uciMove[0], uciMove[1]);
+  core::Square to = parseSquare(uciMove[2], uciMove[3]);
+  if (from == core::NO_SQUARE || to == core::NO_SQUARE) return false;
+
+  core::PieceType promotion = core::PieceType::None;
+  if (uciMove.size() >= 5) promotion = promotionFromChar(uciMove[4]);
+
+  const auto &moves = m_game.generateLegalMoves();
+  for (const auto &m : moves) {
+    if (m.from() != from || m.to() != to) continue;
+    if (m.promotion() != promotion) continue;
+    applyMoveAndNotify(m, false);
+    return true;
+  }
+  return false;
+}
+
+void GameManager::resumeBotsAfterImport() {
+  std::lock_guard lock(m_mutex);
+  if (m_bot_future.valid()) {
+    m_bot_future.wait();
+    m_bot_future = std::future<model::Move>();
+  }
+  m_cancel_bot.store(false);
+  m_suspendBots = false;
+  startBotIfNeeded();
 }
 
 void GameManager::update([[maybe_unused]] float dt) {
@@ -131,6 +194,9 @@ void GameManager::startBotIfNeeded() {
     p = m_white_player.get();
   else
     p = m_black_player.get();
+
+  if (m_suspendBots) return;
+  if (m_bot_future.valid()) return;
 
   if (p && !p->isHuman()) {
     // cancel any running bot

--- a/src/lilia/model/fen_validator.cpp
+++ b/src/lilia/model/fen_validator.cpp
@@ -1,0 +1,101 @@
+#include "lilia/model/fen_validator.hpp"
+
+#include <cctype>
+#include <sstream>
+#include <string>
+
+namespace lilia::model {
+
+namespace {
+
+bool isValidBoard(const std::string &boardField) {
+  int rankCount = 0;
+  std::size_t i = 0;
+  while (i < boardField.size()) {
+    int fileSum = 0;
+    while (i < boardField.size() && boardField[i] != '/') {
+      char c = boardField[i++];
+      if (std::isdigit(static_cast<unsigned char>(c))) {
+        int n = c - '0';
+        if (n <= 0 || n > 8) return false;
+        fileSum += n;
+      } else {
+        switch (c) {
+          case 'p':
+          case 'r':
+          case 'n':
+          case 'b':
+          case 'q':
+          case 'k':
+          case 'P':
+          case 'R':
+          case 'N':
+          case 'B':
+          case 'Q':
+          case 'K':
+            ++fileSum;
+            break;
+          default:
+            return false;
+        }
+      }
+      if (fileSum > 8) return false;
+    }
+    if (fileSum != 8) return false;
+    ++rankCount;
+    if (i < boardField.size() && boardField[i] == '/') ++i;
+  }
+  return rankCount == 8;
+}
+
+bool isCastlingFieldValid(const std::string &field) {
+  if (field == "-") return true;
+  for (char c : field) {
+    if (c != 'K' && c != 'Q' && c != 'k' && c != 'q') return false;
+  }
+  return true;
+}
+
+bool isEnPassantFieldValid(const std::string &field) {
+  if (field == "-") return true;
+  if (field.size() != 2) return false;
+  char file = field[0];
+  char rank = field[1];
+  if (file < 'a' || file > 'h') return false;
+  return rank == '3' || rank == '6';
+}
+
+bool isNonNegativeInteger(const std::string &field) {
+  if (field.empty()) return false;
+  for (char c : field) {
+    if (!std::isdigit(static_cast<unsigned char>(c))) return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+bool isFenWellFormed(const std::string &fen) {
+  std::istringstream ss(fen);
+  std::string fields[6];
+  for (int i = 0; i < 6; ++i) {
+    if (!(ss >> fields[i])) return false;
+  }
+  std::string extra;
+  if (ss >> extra) return false;
+
+  if (!isValidBoard(fields[0])) return false;
+
+  if (!(fields[1] == "w" || fields[1] == "b")) return false;
+
+  if (!isCastlingFieldValid(fields[2])) return false;
+
+  if (!isEnPassantFieldValid(fields[3])) return false;
+
+  if (!isNonNegativeInteger(fields[4])) return false;
+  if (!isNonNegativeInteger(fields[5])) return false;
+
+  return true;
+}
+
+}  // namespace lilia::model

--- a/src/lilia/model/pgn_parser.cpp
+++ b/src/lilia/model/pgn_parser.cpp
@@ -1,0 +1,343 @@
+#include "lilia/model/pgn_parser.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "lilia/constants.hpp"
+#include "lilia/model/chess_game.hpp"
+#include "lilia/model/fen_validator.hpp"
+#include "lilia/model/move.hpp"
+#include "lilia/model/position.hpp"
+#include "lilia/uci/uci_helper.hpp"
+
+namespace lilia::model {
+
+namespace {
+
+bool equalsIgnoreCase(const std::string &a, const std::string &b) {
+  if (a.size() != b.size()) return false;
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(a[i])) !=
+        std::tolower(static_cast<unsigned char>(b[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool isResultToken(const std::string &token) {
+  return token == "1-0" || token == "0-1" || token == "1/2-1/2" || token == "*";
+}
+
+core::PieceType promotionFromChar(char c) {
+  switch (std::tolower(static_cast<unsigned char>(c))) {
+    case 'q':
+      return core::PieceType::Queen;
+    case 'r':
+      return core::PieceType::Rook;
+    case 'b':
+      return core::PieceType::Bishop;
+    case 'n':
+      return core::PieceType::Knight;
+    default:
+      return core::PieceType::None;
+  }
+}
+
+core::Square squareFromStr(const std::string &sq) {
+  if (sq.size() != 2) return core::NO_SQUARE;
+  char file = static_cast<char>(std::tolower(static_cast<unsigned char>(sq[0])));
+  char rank = sq[1];
+  if (file < 'a' || file > 'h' || rank < '1' || rank > '8') return core::NO_SQUARE;
+  const uint8_t f = static_cast<uint8_t>(file - 'a');
+  const uint8_t r = static_cast<uint8_t>(rank - '1');
+  return static_cast<core::Square>(f + r * 8);
+}
+
+std::string cleanToken(std::string token) {
+  // Remove trailing annotations (+, #, !, ?)
+  while (!token.empty()) {
+    char c = token.back();
+    if (c == '+' || c == '#' || c == '!' || c == '?') {
+      token.pop_back();
+    } else {
+      break;
+    }
+  }
+  // Remove "e.p." suffix if present
+  const std::string ep1 = "e.p.";
+  if (token.size() >= ep1.size()) {
+    std::string tail = token.substr(token.size() - ep1.size());
+    std::transform(tail.begin(), tail.end(), tail.begin(), [](unsigned char ch) {
+      return static_cast<char>(std::tolower(ch));
+    });
+    if (tail == ep1) {
+      token.erase(token.size() - ep1.size());
+    }
+  }
+  return token;
+}
+
+bool parseSanMove(const std::string &rawToken, ChessGame &game, model::Move &outMove) {
+  std::string token = cleanToken(rawToken);
+  if (token.empty()) return false;
+
+  std::string upper = token;
+  std::transform(upper.begin(), upper.end(), upper.begin(), [](unsigned char c) {
+    return static_cast<char>(std::toupper(c));
+  });
+
+  const auto &legal = game.generateLegalMoves();
+  auto &board = game.getPositionRefForBot().getBoard();
+
+  if (upper == "O-O" || upper == "0-0") {
+    for (const auto &mv : legal) {
+      if (mv.castle() == model::CastleSide::KingSide) {
+        outMove = mv;
+        return true;
+      }
+    }
+    return false;
+  }
+  if (upper == "O-O-O" || upper == "0-0-0") {
+    for (const auto &mv : legal) {
+      if (mv.castle() == model::CastleSide::QueenSide) {
+        outMove = mv;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  core::PieceType promotion = core::PieceType::None;
+  std::size_t eqPos = token.find('=');
+  if (eqPos != std::string::npos) {
+    if (eqPos + 1 >= token.size()) return false;
+    promotion = promotionFromChar(token[eqPos + 1]);
+    if (promotion == core::PieceType::None) return false;
+    token.erase(eqPos);  // remove "=Q" etc.
+  }
+
+  bool capture = token.find('x') != std::string::npos;
+  token.erase(std::remove(token.begin(), token.end(), 'x'), token.end());
+
+  if (token.size() < 2) return false;
+  std::string targetStr = token.substr(token.size() - 2);
+  core::Square target = squareFromStr(targetStr);
+  if (target == core::NO_SQUARE) return false;
+
+  token.erase(token.size() - 2);
+
+  core::PieceType piece = core::PieceType::Pawn;
+  std::size_t pos = 0;
+  if (!token.empty() && std::isupper(static_cast<unsigned char>(token[0])) &&
+      token[0] != 'O') {
+    switch (token[0]) {
+      case 'K':
+        piece = core::PieceType::King;
+        break;
+      case 'Q':
+        piece = core::PieceType::Queen;
+        break;
+      case 'R':
+        piece = core::PieceType::Rook;
+        break;
+      case 'B':
+        piece = core::PieceType::Bishop;
+        break;
+      case 'N':
+        piece = core::PieceType::Knight;
+        break;
+      default:
+        return false;
+    }
+    pos = 1;
+  }
+
+  std::optional<int> fileHint;
+  std::optional<int> rankHint;
+  for (std::size_t i = pos; i < token.size(); ++i) {
+    char c = token[i];
+    if (c >= 'a' && c <= 'h') {
+      fileHint = c - 'a';
+    } else if (c >= '1' && c <= '8') {
+      rankHint = c - '1';
+    } else {
+      return false;
+    }
+  }
+
+  for (const auto &mv : legal) {
+    if (mv.to() != target) continue;
+    auto pieceOpt = board.getPiece(mv.from());
+    if (!pieceOpt) continue;
+    if (pieceOpt->type != piece) continue;
+    if (promotion != mv.promotion()) continue;
+    if (fileHint && model::bb::file_of(mv.from()) != *fileHint) continue;
+    if (rankHint && model::bb::rank_of(mv.from()) != *rankHint) continue;
+    if (piece == core::PieceType::Pawn) {
+      // Pawn SAN encodes originating file on captures
+      if (capture && fileHint && model::bb::file_of(mv.from()) != *fileHint) continue;
+      if (!capture && mv.isCapture()) continue;
+    } else {
+      if (capture != mv.isCapture()) continue;
+    }
+    outMove = mv;
+    return true;
+  }
+  return false;
+}
+
+std::string stripCommentsAndVariations(const std::string &text) {
+  std::string cleaned;
+  cleaned.reserve(text.size());
+  int variationDepth = 0;
+  bool inBrace = false;
+  bool inSemicolonComment = false;
+
+  for (char ch : text) {
+    if (inSemicolonComment) {
+      if (ch == '\n' || ch == '\r') {
+        inSemicolonComment = false;
+        cleaned.push_back(' ');
+      }
+      continue;
+    }
+    if (inBrace) {
+      if (ch == '}') inBrace = false;
+      continue;
+    }
+    if (ch == ';') {
+      inSemicolonComment = true;
+      continue;
+    }
+    if (ch == '{') {
+      inBrace = true;
+      continue;
+    }
+    if (ch == '(') {
+      ++variationDepth;
+      continue;
+    }
+    if (ch == ')') {
+      if (variationDepth > 0) --variationDepth;
+      continue;
+    }
+    if (variationDepth > 0) continue;
+
+    if (std::isspace(static_cast<unsigned char>(ch))) {
+      if (!cleaned.empty() && cleaned.back() != ' ') cleaned.push_back(' ');
+    } else {
+      cleaned.push_back(ch);
+    }
+  }
+  return cleaned;
+}
+
+std::unordered_map<std::string, std::string> parseTags(const std::string &pgn) {
+  std::unordered_map<std::string, std::string> tags;
+  std::istringstream iss(pgn);
+  std::string line;
+  while (std::getline(iss, line)) {
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    if (line.empty()) continue;
+    if (line.front() != '[') continue;
+    auto close = line.find(']');
+    if (close == std::string::npos) continue;
+    std::string inner = line.substr(1, close - 1);
+    auto space = inner.find(' ');
+    if (space == std::string::npos) continue;
+    std::string key = inner.substr(0, space);
+    std::string value = inner.substr(space + 1);
+    if (!value.empty() && value.front() == '"') value.erase(value.begin());
+    if (!value.empty() && value.back() == '"') value.pop_back();
+    if (!key.empty()) tags[key] = value;
+  }
+  return tags;
+}
+
+std::string extractMovesSection(const std::string &pgn) {
+  std::ostringstream oss;
+  std::istringstream iss(pgn);
+  std::string line;
+  while (std::getline(iss, line)) {
+    if (!line.empty() && line.front() == '[') continue;
+    oss << line << '\n';
+  }
+  return oss.str();
+}
+
+}  // namespace
+
+bool parsePgn(const std::string &pgnText, PgnImport &outImport, std::string *error) {
+  outImport = {};
+  outImport.startFen = core::START_FEN;
+  outImport.finalFen = core::START_FEN;
+  outImport.movesUci.clear();
+  outImport.termination.clear();
+
+  auto tags = parseTags(pgnText);
+  if (auto itFen = tags.find("FEN"); itFen != tags.end()) {
+    if (!isFenWellFormed(itFen->second)) {
+      if (error) *error = "PGN FEN tag is invalid.";
+      return false;
+    }
+    outImport.startFen = itFen->second;
+  }
+  if (auto itSetup = tags.find("SetUp"); itSetup != tags.end()) {
+    if (equalsIgnoreCase(itSetup->second, "0") && tags.contains("FEN")) {
+      // Explicitly indicate standard start despite FEN tag
+      outImport.startFen = core::START_FEN;
+    }
+  }
+
+  std::string movesSection = extractMovesSection(pgnText);
+  std::string stripped = stripCommentsAndVariations(movesSection);
+
+  std::istringstream tokens(stripped);
+  std::string token;
+
+  ChessGame game;
+  game.setPosition(outImport.startFen);
+
+  // Keep track of current FEN for final state
+  outImport.finalFen = game.getFen();
+
+  while (tokens >> token) {
+    if (token.empty()) continue;
+    if (token.find('.') != std::string::npos) {
+      // skip move numbers like "1." or "23..."
+      continue;
+    }
+    if (isResultToken(token)) {
+      outImport.termination = token;
+      break;
+    }
+
+    model::Move mv;
+    if (!parseSanMove(token, game, mv)) {
+      if (error) {
+        *error = "Failed to parse SAN token: " + token;
+      }
+      return false;
+    }
+    outImport.movesUci.push_back(move_to_uci(mv));
+    game.doMove(mv.from(), mv.to(), mv.promotion());
+    outImport.finalFen = game.getFen();
+  }
+
+  if (outImport.movesUci.empty()) {
+    if (error) *error = "PGN contains no moves.";
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace lilia::model

--- a/src/lilia/view/start_screen_dialogs.cpp
+++ b/src/lilia/view/start_screen_dialogs.cpp
@@ -1,0 +1,505 @@
+#include "lilia/view/start_screen_dialogs.hpp"
+
+#include <SFML/Window/Clipboard.hpp>
+#include <algorithm>
+
+#include "lilia/view/color_palette_manager.hpp"
+
+namespace lilia::view {
+
+namespace {
+constexpr float kPanelWidth = 520.f;
+constexpr float kPanelHeight = 420.f;
+constexpr float kFieldPad = 14.f;
+constexpr float kLineHeight = 24.f;
+constexpr float kCaretWidth = 2.f;
+constexpr float kPlaceholderAlpha = 120.f;
+
+sf::Color overlayColor() {
+  sf::Color c = ColorPaletteManager::get().palette().COL_BG_BOTTOM;
+  c.a = 160;
+  return c;
+}
+
+sf::Color panelColor() {
+  return ColorPaletteManager::get().palette().COL_PANEL;
+}
+
+sf::Color borderColor() {
+  return ColorPaletteManager::get().palette().COL_PANEL_BORDER_ALT;
+}
+
+sf::Color inputColor() {
+  return ColorPaletteManager::get().palette().COL_INPUT_BG;
+}
+
+sf::Color inputBorderColor() {
+  return ColorPaletteManager::get().palette().COL_INPUT_BORDER;
+}
+
+sf::Color textColor() {
+  return ColorPaletteManager::get().palette().COL_TEXT;
+}
+
+sf::Color subtleTextColor() {
+  return ColorPaletteManager::get().palette().COL_MUTED_TEXT;
+}
+
+sf::Color accentColor() {
+  return ColorPaletteManager::get().palette().COL_ACCENT;
+}
+
+float measureTextWidth(const sf::Text &text) {
+  return text.getLocalBounds().width;
+}
+
+}  // namespace
+
+LoadGameModal::LoadGameModal(const sf::Font &font) : m_font(font) {
+  m_overlay.setFillColor(overlayColor());
+  m_panel.setSize({kPanelWidth, kPanelHeight});
+  m_panel.setFillColor(panelColor());
+  m_panel.setOutlineThickness(2.f);
+  m_panel.setOutlineColor(borderColor());
+
+  m_title.setFont(m_font);
+  m_title.setCharacterSize(26);
+  m_title.setString("Load Game");
+  m_title.setFillColor(textColor());
+
+  m_fenLabel.setFont(m_font);
+  m_fenLabel.setCharacterSize(16);
+  m_fenLabel.setString("FEN");
+  m_fenLabel.setFillColor(subtleTextColor());
+
+  m_pgnLabel = m_fenLabel;
+  m_pgnLabel.setString("PGN");
+
+  m_fenText.setFont(m_font);
+  m_fenText.setCharacterSize(16);
+  m_fenText.setFillColor(textColor());
+
+  m_pgnText.setFont(m_font);
+  m_pgnText.setCharacterSize(15);
+  m_pgnText.setFillColor(textColor());
+
+  m_fenPlaceholder = m_fenText;
+  m_fenPlaceholder.setFillColor(sf::Color(textColor().r, textColor().g, textColor().b, 110));
+  m_fenPlaceholder.setString("Leave empty to use standard start");
+
+  m_pgnPlaceholder = m_pgnText;
+  m_pgnPlaceholder.setFillColor(sf::Color(textColor().r, textColor().g, textColor().b, 110));
+  m_pgnPlaceholder.setString("Paste PGN moves here");
+
+  m_fenBox.setFillColor(inputColor());
+  m_fenBox.setOutlineThickness(2.f);
+  m_fenBox.setOutlineColor(inputBorderColor());
+
+  m_pgnBox = m_fenBox;
+
+  m_closeButton.setSize({32.f, 32.f});
+  m_closeButton.setFillColor(sf::Color::Transparent);
+  m_closeButton.setOutlineThickness(2.f);
+  m_closeButton.setOutlineColor(subtleTextColor());
+
+  m_closeText.setFont(m_font);
+  m_closeText.setCharacterSize(20);
+  m_closeText.setString("×");
+  m_closeText.setFillColor(subtleTextColor());
+}
+
+void LoadGameModal::open(const std::string &fen, const std::string &pgn) {
+  m_visible = true;
+  m_fenString = fen;
+  m_pgnString = pgn;
+  m_fenActive = true;
+  m_pgnActive = false;
+  resetCaret();
+}
+
+void LoadGameModal::close() { m_visible = false; }
+
+bool LoadGameModal::isOpen() const { return m_visible; }
+
+void LoadGameModal::layout(const sf::Vector2u &windowSize) {
+  m_overlay.setSize({static_cast<float>(windowSize.x), static_cast<float>(windowSize.y)});
+  const sf::Vector2f center{static_cast<float>(windowSize.x) * 0.5f,
+                            static_cast<float>(windowSize.y) * 0.5f};
+  m_panel.setPosition(center.x - kPanelWidth * 0.5f, center.y - kPanelHeight * 0.5f);
+
+  m_title.setPosition(m_panel.getPosition().x + kFieldPad,
+                      m_panel.getPosition().y + kFieldPad);
+
+  m_closeButton.setPosition(m_panel.getPosition().x + kPanelWidth - m_closeButton.getSize().x -
+                                kFieldPad * 0.5f,
+                            m_panel.getPosition().y + kFieldPad * 0.5f);
+  auto closeBounds = m_closeText.getLocalBounds();
+  m_closeText.setOrigin(closeBounds.left + closeBounds.width * 0.5f,
+                        closeBounds.top + closeBounds.height * 0.5f);
+  m_closeText.setPosition(m_closeButton.getPosition().x + m_closeButton.getSize().x * 0.5f,
+                          m_closeButton.getPosition().y + m_closeButton.getSize().y * 0.5f);
+
+  const float fieldLeft = m_panel.getPosition().x + kFieldPad;
+  float cursorY = m_title.getPosition().y + 48.f;
+
+  m_fenLabel.setPosition(fieldLeft, cursorY);
+  cursorY += kLineHeight;
+  m_fenBox.setPosition(fieldLeft, cursorY);
+  m_fenBox.setSize({kPanelWidth - 2.f * kFieldPad, 38.f});
+  cursorY += m_fenBox.getSize().y + kFieldPad;
+
+  m_pgnLabel.setPosition(fieldLeft, cursorY);
+  cursorY += kLineHeight;
+  m_pgnBox.setPosition(fieldLeft, cursorY);
+  m_pgnBox.setSize({kPanelWidth - 2.f * kFieldPad, kPanelHeight - (cursorY - m_panel.getPosition().y) -
+                                             kFieldPad});
+
+  refreshTexts();
+}
+
+void LoadGameModal::refreshTexts() {
+  const float fenTextX = m_fenBox.getPosition().x + kFieldPad;
+  const float fenTextY = m_fenBox.getPosition().y + m_fenBox.getSize().y * 0.5f - 8.f;
+  m_fenText.setString(m_fenString);
+  m_fenText.setPosition(fenTextX, fenTextY);
+  m_fenPlaceholder.setPosition(fenTextX, fenTextY);
+
+  const float pgnTextX = m_pgnBox.getPosition().x + kFieldPad;
+  const float pgnTextY = m_pgnBox.getPosition().y + kFieldPad;
+  m_pgnText.setString(m_pgnString);
+  m_pgnText.setPosition(pgnTextX, pgnTextY);
+  m_pgnPlaceholder.setPosition(pgnTextX, pgnTextY);
+
+  m_fenCaretX = m_fenText.getPosition().x + measureTextWidth(m_fenText);
+  const std::string &pgn = m_pgnString;
+  std::size_t lastNewline = pgn.rfind('\n');
+  std::string lastLine = (lastNewline == std::string::npos) ? pgn : pgn.substr(lastNewline + 1);
+  sf::Text tmp(lastLine, m_font, m_pgnText.getCharacterSize());
+  m_pgnCaretX = m_pgnText.getPosition().x + measureTextWidth(tmp);
+  int lineCount = 0;
+  for (char c : pgn) {
+    if (c == '\n') ++lineCount;
+  }
+  m_pgnCaretY = m_pgnText.getPosition().y + static_cast<float>(lineCount) *
+                                         (m_pgnText.getCharacterSize() + 4.f);
+}
+
+void LoadGameModal::resetCaret() {
+  m_caretClock.restart();
+  refreshTexts();
+}
+
+void LoadGameModal::updateCaretVisibility() {
+  if (m_caretClock.getElapsedTime().asSeconds() > 0.8f) {
+    m_caretClock.restart();
+  }
+}
+
+bool LoadGameModal::handleTextEntered(sf::Uint32 unicode) {
+  if (unicode == 8) {  // backspace
+    if (m_fenActive) {
+      if (!m_fenString.empty()) m_fenString.pop_back();
+    } else if (m_pgnActive) {
+      if (!m_pgnString.empty()) m_pgnString.pop_back();
+    }
+    resetCaret();
+    return true;
+  }
+  if (unicode == 13) {  // enter
+    if (m_pgnActive) {
+      m_pgnString.push_back('\n');
+      resetCaret();
+      return true;
+    }
+    return false;
+  }
+  if (unicode < 32 || unicode > 126) return false;
+  char c = static_cast<char>(unicode);
+  if (m_fenActive) {
+    std::string probe = m_fenString;
+    probe.push_back(c);
+    sf::Text tmp(probe, m_font, m_fenText.getCharacterSize());
+    if (tmp.getLocalBounds().width <= m_fenBox.getSize().x - 2.f * kFieldPad) {
+      m_fenString.push_back(c);
+      resetCaret();
+      return true;
+    }
+    return false;
+  }
+  if (m_pgnActive) {
+    m_pgnString.push_back(c);
+    resetCaret();
+    return true;
+  }
+  return false;
+}
+
+bool LoadGameModal::handleKeyPressed(const sf::Event::KeyEvent &key, bool ctrlDown) {
+  if (ctrlDown && key.code == sf::Keyboard::V) {
+    pasteFromClipboard();
+    return true;
+  }
+  if (key.code == sf::Keyboard::Tab) {
+    if (m_fenActive) {
+      m_fenActive = false;
+      m_pgnActive = true;
+    } else {
+      m_fenActive = true;
+      m_pgnActive = false;
+    }
+    resetCaret();
+    return true;
+  }
+  if (key.code == sf::Keyboard::Escape) {
+    m_visible = false;
+    return true;
+  }
+  return false;
+}
+
+void LoadGameModal::pasteFromClipboard() {
+  auto clip = sf::Clipboard::getString().toAnsiString();
+  if (clip.empty()) return;
+  if (m_fenActive) {
+    std::string filtered;
+    filtered.reserve(clip.size());
+    for (char c : clip) {
+      if (c == '\n' || c == '\r') continue;
+      if (c >= 32 && c <= 126) filtered.push_back(c);
+    }
+    for (char c : filtered) {
+      sf::Text tmp(m_fenString + c, m_font, m_fenText.getCharacterSize());
+      if (tmp.getLocalBounds().width <= m_fenBox.getSize().x - 2.f * kFieldPad)
+        m_fenString.push_back(c);
+      else
+        break;
+    }
+  } else if (m_pgnActive) {
+    for (char c : clip) {
+      if (c == '\r') continue;
+      if (c == '\t') {
+        m_pgnString.push_back(' ');
+      } else {
+        m_pgnString.push_back(c);
+      }
+    }
+  }
+  resetCaret();
+}
+
+LoadGameModal::EventResult LoadGameModal::handleEvent(const sf::Event &event,
+                                                      sf::Vector2f mousePos) {
+  if (!m_visible) return EventResult::None;
+  if (event.type == sf::Event::MouseButtonPressed &&
+      event.mouseButton.button == sf::Mouse::Left) {
+    if (m_closeButton.getGlobalBounds().contains(mousePos)) {
+      m_visible = false;
+      return EventResult::Closed;
+    }
+    if (m_fenBox.getGlobalBounds().contains(mousePos)) {
+      m_fenActive = true;
+      m_pgnActive = false;
+      resetCaret();
+    } else if (m_pgnBox.getGlobalBounds().contains(mousePos)) {
+      m_fenActive = false;
+      m_pgnActive = true;
+      resetCaret();
+    }
+  }
+  if (event.type == sf::Event::TextEntered) {
+    if (handleTextEntered(event.text.unicode)) return EventResult::None;
+  }
+  if (event.type == sf::Event::KeyPressed) {
+    bool ctrl = event.key.control || event.key.system;
+    if (handleKeyPressed(event.key, ctrl)) {
+      if (!m_visible) return EventResult::Closed;
+      return EventResult::None;
+    }
+  }
+  updateCaretVisibility();
+  return EventResult::None;
+}
+
+void LoadGameModal::drawCaret(sf::RenderWindow &window) const {
+  if (!m_visible) return;
+  if (m_caretClock.getElapsedTime().asSeconds() > 0.5f) return;
+  sf::RectangleShape caret;
+  caret.setFillColor(textColor());
+  caret.setSize({kCaretWidth, m_fenBox.getSize().y - 12.f});
+  if (m_fenActive) {
+    caret.setPosition(m_fenCaretX, m_fenBox.getPosition().y + 6.f);
+    window.draw(caret);
+  } else if (m_pgnActive) {
+    caret.setSize({kCaretWidth, static_cast<float>(m_pgnText.getCharacterSize() + 4)});
+    caret.setPosition(m_pgnCaretX,
+                      m_pgnCaretY);
+    window.draw(caret);
+  }
+}
+
+void LoadGameModal::draw(sf::RenderWindow &window) {
+  if (!m_visible) return;
+  layout(window.getSize());
+
+  window.draw(m_overlay);
+  window.draw(m_panel);
+  window.draw(m_title);
+  window.draw(m_closeButton);
+  window.draw(m_closeText);
+  window.draw(m_fenLabel);
+  window.draw(m_fenBox);
+  if (m_fenString.empty())
+    window.draw(m_fenPlaceholder);
+  else
+    window.draw(m_fenText);
+  window.draw(m_pgnLabel);
+  window.draw(m_pgnBox);
+  if (m_pgnString.empty())
+    window.draw(m_pgnPlaceholder);
+  else
+    window.draw(m_pgnText);
+
+  drawCaret(window);
+}
+
+void LoadGameModal::applyTheme() {
+  m_overlay.setFillColor(overlayColor());
+  m_panel.setFillColor(panelColor());
+  m_panel.setOutlineColor(borderColor());
+  m_fenBox.setFillColor(inputColor());
+  m_fenBox.setOutlineColor(inputBorderColor());
+  m_pgnBox.setFillColor(inputColor());
+  m_pgnBox.setOutlineColor(inputBorderColor());
+  m_title.setFillColor(textColor());
+  m_fenLabel.setFillColor(subtleTextColor());
+  m_pgnLabel.setFillColor(subtleTextColor());
+  m_fenText.setFillColor(textColor());
+  m_pgnText.setFillColor(textColor());
+  m_fenPlaceholder.setFillColor(sf::Color(textColor().r, textColor().g, textColor().b, 110));
+  m_pgnPlaceholder.setFillColor(sf::Color(textColor().r, textColor().g, textColor().b, 110));
+  m_closeButton.setOutlineColor(subtleTextColor());
+  m_closeText.setFillColor(subtleTextColor());
+}
+
+/* ---------------- WarningDialog ---------------- */
+
+WarningDialog::WarningDialog(const sf::Font &font) : m_font(font) {
+  m_overlay.setFillColor(overlayColor());
+  m_panel.setSize({380.f, 180.f});
+  m_panel.setFillColor(panelColor());
+  m_panel.setOutlineThickness(2.f);
+  m_panel.setOutlineColor(borderColor());
+
+  m_message.setFont(m_font);
+  m_message.setCharacterSize(18);
+  m_message.setFillColor(textColor());
+
+  m_acceptBtn.setSize({150.f, 40.f});
+  m_acceptBtn.setFillColor(accentColor());
+  m_acceptBtn.setOutlineThickness(0.f);
+
+  m_cancelBtn = m_acceptBtn;
+  m_cancelBtn.setFillColor(inputColor());
+  m_cancelBtn.setOutlineThickness(2.f);
+  m_cancelBtn.setOutlineColor(inputBorderColor());
+
+  m_acceptText.setFont(m_font);
+  m_acceptText.setCharacterSize(16);
+  m_acceptText.setString("Use defaults");
+  m_acceptText.setFillColor(ColorPaletteManager::get().palette().COL_DARK_TEXT);
+
+  m_cancelText.setFont(m_font);
+  m_cancelText.setCharacterSize(16);
+  m_cancelText.setString("Back");
+  m_cancelText.setFillColor(textColor());
+}
+
+void WarningDialog::open(const std::string &message) {
+  m_visible = true;
+  m_message.setString(message);
+}
+
+void WarningDialog::close() { m_visible = false; }
+
+bool WarningDialog::isOpen() const { return m_visible; }
+
+void WarningDialog::layout(const sf::Vector2u &windowSize) {
+  m_overlay.setSize({static_cast<float>(windowSize.x), static_cast<float>(windowSize.y)});
+  const sf::Vector2f center{static_cast<float>(windowSize.x) * 0.5f,
+                            static_cast<float>(windowSize.y) * 0.5f};
+  m_panel.setPosition(center.x - m_panel.getSize().x * 0.5f,
+                      center.y - m_panel.getSize().y * 0.5f);
+
+  sf::FloatRect msgBounds = m_message.getLocalBounds();
+  m_message.setOrigin(msgBounds.left + msgBounds.width * 0.5f,
+                      msgBounds.top + msgBounds.height * 0.5f);
+  m_message.setPosition(center.x, m_panel.getPosition().y + 60.f);
+
+  const float buttonY = m_panel.getPosition().y + m_panel.getSize().y - 60.f;
+  const float gap = 20.f;
+  m_acceptBtn.setPosition(center.x - m_acceptBtn.getSize().x - gap * 0.5f, buttonY);
+  m_cancelBtn.setPosition(center.x + gap * 0.5f, buttonY);
+
+  auto centerText = [](sf::Text &txt, const sf::RectangleShape &box) {
+    auto b = txt.getLocalBounds();
+    txt.setOrigin(b.left + b.width * 0.5f, b.top + b.height * 0.5f);
+    txt.setPosition(box.getPosition().x + box.getSize().x * 0.5f,
+                    box.getPosition().y + box.getSize().y * 0.5f);
+  };
+
+  centerText(m_acceptText, m_acceptBtn);
+  centerText(m_cancelText, m_cancelBtn);
+}
+
+WarningDialog::Choice WarningDialog::handleEvent(const sf::Event &event,
+                                                  sf::Vector2f mousePos) {
+  if (!m_visible) return Choice::None;
+  if (event.type == sf::Event::MouseButtonPressed &&
+      event.mouseButton.button == sf::Mouse::Left) {
+    if (m_acceptBtn.getGlobalBounds().contains(mousePos)) {
+      m_visible = false;
+      return Choice::UseDefaults;
+    }
+    if (m_cancelBtn.getGlobalBounds().contains(mousePos)) {
+      m_visible = false;
+      return Choice::Cancel;
+    }
+  }
+  if (event.type == sf::Event::KeyPressed) {
+    if (event.key.code == sf::Keyboard::Enter) {
+      m_visible = false;
+      return Choice::UseDefaults;
+    }
+    if (event.key.code == sf::Keyboard::Escape) {
+      m_visible = false;
+      return Choice::Cancel;
+    }
+  }
+  return Choice::None;
+}
+
+void WarningDialog::draw(sf::RenderWindow &window) {
+  if (!m_visible) return;
+  layout(window.getSize());
+  window.draw(m_overlay);
+  window.draw(m_panel);
+  window.draw(m_message);
+  window.draw(m_acceptBtn);
+  window.draw(m_cancelBtn);
+  window.draw(m_acceptText);
+  window.draw(m_cancelText);
+}
+
+void WarningDialog::applyTheme() {
+  m_overlay.setFillColor(overlayColor());
+  m_panel.setFillColor(panelColor());
+  m_panel.setOutlineColor(borderColor());
+  m_message.setFillColor(textColor());
+  m_acceptBtn.setFillColor(accentColor());
+  m_acceptText.setFillColor(ColorPaletteManager::get().palette().COL_DARK_TEXT);
+  m_cancelBtn.setFillColor(inputColor());
+  m_cancelBtn.setOutlineColor(inputBorderColor());
+  m_cancelText.setFillColor(textColor());
+}
+
+}  // namespace lilia::view


### PR DESCRIPTION
## Summary
- replace the inline FEN textbox with a Load Game modal and warning dialog on the start screen
- add reusable FEN validation and PGN parsing utilities to drive imports
- extend the app and controllers to replay PGN history and populate the move list before starting bots

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d67c504bfc8329b9bd79799e8cc177