### PR TITLE
Add load game popup to start screen

### DIFF
--- a/include/lilia/controller/game_controller.hpp
+++ b/include/lilia/controller/game_controller.hpp
@@ -91,6 +91,8 @@ public:
                  int blackThinkTimeMs = 1000, int blackDepth = 5,
                  bool useTimer = true, int baseSeconds = 0,
                  int incrementSeconds = 0);
+  void setInitialPgn(const std::string &pgn,
+                     const std::vector<std::string> &uciMoves);
 
   enum class NextAction { None, NewBot, Rematch };
   [[nodiscard]] NextAction getNextAction() const;
@@ -146,6 +148,8 @@ private:
   model::ChessGame &m_chess_game; ///< Game model containing rules and state.
   InputManager m_input_manager;   ///< Handles raw input processing.
   view::sound::SoundManager m_sound_manager; ///< Handles sfx and music
+  std::string m_initial_pgn;
+  std::vector<std::string> m_initial_pgn_moves;
 
   bool m_white_is_bot{false};
   bool m_black_is_bot{false};

--- a/include/lilia/controller/game_manager.hpp
+++ b/include/lilia/controller/game_manager.hpp
@@ -33,7 +33,11 @@ public:
   void startGame(const std::string &fen = core::START_FEN,
                  bool whiteIsBot = false, bool blackIsBot = true,
                  int whiteThinkTimeMs = 1000, int whiteDepth = 5,
-                 int blackThinkTimeMs = 1000, int blackDepth = 5);
+                 int blackThinkTimeMs = 1000, int blackDepth = 5,
+                 bool startBotImmediately = true);
+
+  bool applyMoveUci(const std::string &uciMove, bool suppressBotStart = false);
+  void resumeBots();
   void stopGame();
 
   void update(float dt);

--- a/include/lilia/view/start_screen.hpp
+++ b/include/lilia/view/start_screen.hpp
@@ -17,6 +17,8 @@ struct StartConfig {
   bool blackIsBot{true};
   BotType blackBot{BotType::Lilia};
   std::string fen{core::START_FEN};
+  std::string pgn{};
+  std::vector<std::string> pgnMoves;
   int timeBaseSeconds{300};     // default 5 minutes
   int timeIncrementSeconds{0};  // default 0s increment
   bool timeEnabled{true};       // whether clocks are used
@@ -46,7 +48,7 @@ class StartScreen {
   sf::Texture m_logoTex;
   sf::Sprite m_logo;
   sf::Text m_devByText;    // "@Developed by Julian Meyer" bottom-right
-  sf::Text m_fenInfoText;  // subtle hint below FEN box
+  sf::Text m_fenInfoText;  // subtle hint below Load button
 
   sf::RectangleShape m_whitePlayerBtn;
   sf::RectangleShape m_whiteBotBtn;
@@ -83,19 +85,43 @@ class StartScreen {
   bool m_paletteListForceHide{false};
   float m_paletteListAnim{0.f};
 
-  // FEN popup UI
-  bool m_showFenPopup{false};
+  // Load game button
+  sf::RectangleShape m_loadGameBtn;
+  sf::Text m_loadGameText;
+  sf::Text m_loadSummaryText;
+
+  // Load popup UI
+  bool m_showLoadPopup{false};
   sf::RectangleShape m_fenPopup;
   sf::RectangleShape m_fenInputBox;
   sf::Text m_fenInputText;
+  sf::Text m_fenLabelText;
+  sf::Text m_pgnLabelText;
+  sf::RectangleShape m_pgnInputBox;
+  sf::Text m_pgnInputText;
   sf::RectangleShape m_fenBackBtn;
   sf::RectangleShape m_fenContinueBtn;
   sf::Text m_fenBackText;
   sf::Text m_fenContinueText;
   sf::Text m_fenErrorText;
+  sf::Text m_pgnErrorText;
   std::string m_fenString;
+  std::string m_pgnString;
+  std::vector<std::string> m_cachedPgnMoves;
   sf::Clock m_errorClock;
   bool m_showError{false};
+
+  // Warning popup when invalid inputs remain on start
+  bool m_showWarningPopup{false};
+  bool m_warningInvalidFen{false};
+  bool m_warningInvalidPgn{false};
+  sf::RectangleShape m_warningPopup;
+  sf::Text m_warningTitle;
+  sf::Text m_warningBody;
+  sf::RectangleShape m_warningBackBtn;
+  sf::RectangleShape m_warningContinueBtn;
+  sf::Text m_warningBackText;
+  sf::Text m_warningContinueText;
 
   // time control state
   int m_baseSeconds{300};
@@ -137,8 +163,9 @@ class StartScreen {
   void setupUI();
   void applyTheme();
   bool handleMouse(sf::Vector2f pos, StartConfig &cfg);
-  bool handleFenMouse(sf::Vector2f pos, StartConfig &cfg);
   bool isValidFen(const std::string &fen);
+  bool isValidPgn(const std::string &pgn, const std::string &baseFen,
+                  std::vector<std::string> *uciMoves = nullptr);
   void updateTimeToggle();
   void processHoldRepeater(HoldRepeater &r, const sf::FloatRect &bounds, sf::Vector2f mouse,
                            std::function<void()> stepFn, float initialDelay = 0.35f,

--- a/src/lilia/app/app.cpp
+++ b/src/lilia/app/app.cpp
@@ -59,6 +59,7 @@ int App::run() {
       lilia::view::GameView gameView(window, m_black_is_bot, m_white_is_bot);
       lilia::controller::GameController gameController(gameView, chessGame);
 
+      gameController.setInitialPgn(cfg.pgn, cfg.pgnMoves);
       gameController.startGame(m_start_fen, m_white_is_bot, m_black_is_bot, whiteThinkMs,
                                whiteDepth, blackThinkMs, blackDepth, timeEnabled, baseSeconds,
                                incrementSeconds);

--- a/src/lilia/controller/game_controller.cpp
+++ b/src/lilia/controller/game_controller.cpp
@@ -150,7 +150,7 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot,
   m_white_is_bot = whiteIsBot;
   m_black_is_bot = blackIsBot;
   m_game_manager->startGame(fen, whiteIsBot, blackIsBot, whiteThinkTimeMs,
-                            whiteDepth, blackThinkTimeMs, blackDepth);
+                            whiteDepth, blackThinkTimeMs, blackDepth, false);
 
   // Preallocate frequently growing containers to avoid repeated reallocations
   m_fen_history.clear();
@@ -211,6 +211,22 @@ void GameController::startGame(const std::string &fen, bool whiteIsBot,
 
   m_game_view.setDefaultCursor();
   m_next_action = NextAction::None;
+
+  if (!m_initial_pgn_moves.empty()) {
+    for (const auto &uciMove : m_initial_pgn_moves) {
+      if (!m_game_manager->applyMoveUci(uciMove, true)) {
+        break;
+      }
+    }
+  }
+
+  m_game_manager->resumeBots();
+}
+
+void GameController::setInitialPgn(const std::string &pgn,
+                                   const std::vector<std::string> &uciMoves) {
+  m_initial_pgn = pgn;
+  m_initial_pgn_moves = uciMoves;
 }
 
 void GameController::handleEvent(const sf::Event &event) {


### PR DESCRIPTION
## Summary
- replace the inline FEN field with a dedicated Load Game popup for entering FEN and PGN
- validate PGN input by parsing it into UCI moves and store the data with the game configuration
- warn players about invalid inputs before starting and pass PGN details to the game controller

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69ae91bcc83298fd7bfde1ee1556c