### PR TITLE
Guard quiet king-shield pawn pushes during search

### DIFF
--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -259,6 +259,16 @@ static inline int quiet_pawn_push_signal(const model::Board& b, const model::Mov
   // Advanced passed pawn push – treat as tactical to avoid pruning the follow-up
   if (is_advanced_passed_pawn_push(b, m, us)) return 1;
 
+  // Creating luft for our king by moving a shield pawn is critical in many tactical
+  // situations. When the pawn we are pushing was guarding a square around our king,
+  // mark the move as tactical so it isn't discarded by quiet-move pruning.
+  const auto kingBB = b.getPieces(us, PT::King);
+  if (kingBB) {
+    const auto kingSq = static_cast<core::Square>(model::bb::ctz64(kingBB));
+    const auto shield = model::bb::king_attacks_from(kingSq) | model::bb::sq_bb(kingSq);
+    if (model::bb::sq_bb(static_cast<core::Square>(m.from())) & shield) return 1;
+  }
+
   return 0;
 }
 

--- a/tests/tactical_quiet_test.cpp
+++ b/tests/tactical_quiet_test.cpp
@@ -91,6 +91,16 @@ int main() {
     assert(*res.bestMove == expected);
   }
 
+  // Creating luft with a quiet pawn push should be kept
+  {
+    model::ChessGame game;
+    game.setPosition("6k1/3b1ppp/p7/3R4/2P5/4Kp1q/5Q2/8 b - - 1 67");
+    auto res = bot.findBestMove(game, 3, 10);
+    assert(res.bestMove);
+    model::Move expected(sq('h', 7), sq('h', 6));
+    assert(*res.bestMove == expected);
+  }
+
   // Node batching should reset/flush between searches with node limits.
   {
     model::ChessGame game;


### PR DESCRIPTION
## Summary
- treat quiet pawn pushes that vacate squares around the king as tactical so they are not pruned away
- add a regression test that ensures the search finds 6k1/3b1ppp/p7/3R4/2P5/4Kp1q/5Q2/8 b - - 1 67 -> h7h6

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d879d8f4048329bc0f7bf37f10249c