### PR TITLE
Guard check table initialization

### DIFF
--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -522,6 +522,11 @@ static inline bool would_give_check_after(const model::Position& pos, const mode
   return false;
 }
 
+inline void ensure_check_tables_initialized() {
+  static std::once_flag init_flag;
+  std::call_once(init_flag, [] { init_check_tables(); });
+}
+
 }  // namespace
 
 // ---------- Search ----------
@@ -545,7 +550,7 @@ Search::Search(model::TT5& tt_, std::shared_ptr<const Evaluator> eval_, const En
   sharedNodes.reset();  // NEW
   nodeLimit = 0;        // NEW
   stats = SearchStats{};
-  init_check_tables();
+  ensure_check_tables_initialized();
 }
 
 int Search::signed_eval(model::Position& pos) {


### PR DESCRIPTION
## Summary
- guard the expensive check table setup so it only runs once across all searches
- have Search call the guarded initializer so all workers reuse the shared tables

## Testing
- `cmake --build build -j`
- `build/bin/lilia_engine` (uci → setoption Threads 4 → go depth 2)


------
https://chatgpt.com/codex/tasks/task_e_68dac4c062648329b42d1293adf271de