### PR TITLE
Ensure transposition table generation updates for single-thread search

### DIFF
--- a/src/lilia/engine/engine.cpp
+++ b/src/lilia/engine/engine.cpp
@@ -61,11 +61,7 @@ std::optional<model::Move> Engine::find_best_move(model::Position& pos, int maxD
                                                   std::shared_ptr<std::atomic<bool>> stop) {
   if (maxDepth <= 0) maxDepth = pimpl->cfg.maxDepth;
 
-  // Suche immer sauber zurücksetzen (TT, Killers/History etc.)
-  try {
-    pimpl->tt.clear();
-  } catch (...) {
-  }
+  // Suche immer sauber zurücksetzen (Killers/History etc.)
   try {
     pimpl->search->clearSearchState();
   } catch (...) {

--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -2141,13 +2141,13 @@ int Search::search_root_lazy_smp(model::Position& pos, int maxDepth,
                                  std::shared_ptr<std::atomic<bool>> stop, int maxThreads,
                                  std::uint64_t maxNodes) {
   const int threads = std::max(1, maxThreads > 0 ? std::min(maxThreads, cfg.threads) : cfg.threads);
-  if (threads <= 1) return search_root_single(pos, maxDepth, stop, maxNodes);
-
   // Eine gemeinsame TT-Generation
   try {
     tt.new_generation();
   } catch (...) {
   }
+
+  if (threads <= 1) return search_root_single(pos, maxDepth, stop, maxNodes);
 
   auto& pool = ThreadPool::instance();
   auto sharedCounter = std::make_shared<std::atomic<std::uint64_t>>(0);


### PR DESCRIPTION
## Summary
- stop clearing the engine transposition table before every search so entries persist across moves
- keep search heuristics reset each search while ensuring the TT generation increments regardless of thread count

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac4ee946c83299ad01f681c91cae1