### PR TITLE
Guard capturing check extensions with SEE

### DIFF
--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -1491,8 +1491,16 @@ int Search::negamax(model::Position& pos, int depth, int alpha, int beta, int pl
     // Check extension (light)
     const bool givesCheck = pos.lastMoveGaveCheck();
     if (givesCheck) {
-      if (!isQuiet && seeGood) {
-        newDepth += 1;  // capturing checks still get a light extension
+      if (!isQuiet) {
+        bool allowCaptureExt = seeGood;
+        if (allowCaptureExt && m.isCapture()) {
+          const int attackerVal = base_value[(int)moverPt];
+          const int victimVal = capValPre;
+          if (victimVal < attackerVal && !pos.see(m)) {
+            allowCaptureExt = false;  // speculative sacrifices stay shallow
+          }
+        }
+        if (allowCaptureExt) newDepth += 1;  // capturing checks still get a light extension
       } else if (isQuiet) {
         bool okQuietExt = (depth <= 3) &&                    // only shallow
                           (history[m.from()][m.to()] > 0 ||  // some prior success


### PR DESCRIPTION
## Summary
- require capturing check extensions to satisfy SEE or material parity before receiving the light depth bump

## Testing
- ctest --test-dir build
- ./build/bin/lilia_engine <<'EOF'
uci
isready
ucinewgame
position fen r1bqk2r/ppp2ppp/2n5/4p3/2P5/2bP1N2/P2B1PPP/R2QKB1R b KQkq - 1 9
setoption name MultiPV value 4
setoption name Threads value 1
isready
go depth 16
quit
EOF
- ./build/bin/lilia_engine <<'EOF'
uci
isready
ucinewgame
position startpos
isready
go depth 10
quit
EOF

------
https://chatgpt.com/codex/tasks/task_e_68dad8394b008329a7ccef73e6023683