### PR TITLE
Cache quiet move signals during ordering

### DIFF
--- a/include/lilia/engine/move_list.hpp
+++ b/include/lilia/engine/move_list.hpp
@@ -1,21 +1,42 @@
 #pragma once
+#include <tuple>
+#include <utility>
+
 #include "lilia/model/move.hpp"
 
 namespace lilia::engine {
 
 // descending insertion sort on parallel arrays
-inline void sort_by_score_desc(int* score, model::Move* moves, int n) {
+template <typename... PayloadArrays>
+inline void sort_by_score_desc(int* score, model::Move* moves, int n, PayloadArrays... payload) {
   for (int i = 1; i < n; ++i) {
     int s = score[i];
     model::Move m = moves[i];
     int j = i - 1;
-    while (j >= 0 && score[j] < s) {
-      score[j + 1] = score[j];
-      moves[j + 1] = moves[j];
-      --j;
+    if constexpr (sizeof...(payload) > 0) {
+      auto payloadValues = std::tuple{payload[i]...};
+      while (j >= 0 && score[j] < s) {
+        score[j + 1] = score[j];
+        moves[j + 1] = moves[j];
+        ((payload[j + 1] = payload[j]), ...);
+        --j;
+      }
+      score[j + 1] = s;
+      moves[j + 1] = m;
+      std::apply(
+          [&](auto&&... values) {
+            ((payload[j + 1] = std::forward<decltype(values)>(values)), ...);
+          },
+          payloadValues);
+    } else {
+      while (j >= 0 && score[j] < s) {
+        score[j + 1] = score[j];
+        moves[j + 1] = moves[j];
+        --j;
+      }
+      score[j + 1] = s;
+      moves[j + 1] = m;
     }
-    score[j + 1] = s;
-    moves[j + 1] = m;
   }
 }
 


### PR DESCRIPTION
## Summary
- extend the move ordering insertion sort so that auxiliary payload arrays stay aligned with each move
- cache quiet move signals and passed-pawn flags during scoring in `negamax` and reuse them when iterating moves to avoid recomputation

## Testing
- ctest --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68db9687af588329863dd318ffff54bf