### PR TITLE
Validate UCI moves before applying

### DIFF
--- a/include/lilia/model/chess_game.hpp
+++ b/include/lilia/model/chess_game.hpp
@@ -17,7 +17,7 @@ class ChessGame {
 
   void setPosition(const std::string& fen);
   void buildHash();
-  void doMove(core::Square from, core::Square to,
+  bool doMove(core::Square from, core::Square to,
               core::PieceType promotion = core::PieceType::None);
   bool doMoveUCI(const std::string& uciMove);
 

--- a/src/lilia/controller/game_manager.cpp
+++ b/src/lilia/controller/game_manager.cpp
@@ -1,6 +1,7 @@
 #include "lilia/controller/game_manager.hpp"
 
 #include <chrono>
+#include <iostream>
 
 #include "lilia/controller/bot_player.hpp"
 #include "lilia/controller/player.hpp"
@@ -110,7 +111,10 @@ void GameManager::completePendingPromotion(core::PieceType promotion) {
 
 void GameManager::applyMoveAndNotify(const model::Move &mv, bool onClick) {
   const core::Color mover = m_game.getGameState().sideToMove;
-  m_game.doMove(mv.from(), mv.to(), mv.promotion());
+  if (!m_game.doMove(mv.from(), mv.to(), mv.promotion())) {
+    std::cerr << "[GameManager] Failed to apply move.\n";
+    return;
+  }
 
   bool wasPlayerMove = isHuman(mover);
 

--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -81,8 +81,7 @@ bool ChessGame::doMoveUCI(const std::string& uciMove) {
         break;
     }
   }
-  doMove(static_cast<core::Square>(from), static_cast<core::Square>(to), promo);
-  return true;
+  return doMove(static_cast<core::Square>(from), static_cast<core::Square>(to), promo);
 }
 
 std::optional<Move> ChessGame::getMove(core::Square from, core::Square to) {
@@ -288,14 +287,17 @@ bb::Piece ChessGame::getPiece(core::Square sq) {
   return opt.value_or(bb::Piece{core::PieceType::None, core::Color::White});
 }
 
-void ChessGame::doMove(core::Square from, core::Square to, core::PieceType promotion) {
+bool ChessGame::doMove(core::Square from, core::Square to, core::PieceType promotion) {
   const auto& moves = generateLegalMoves();
   for (const auto& m : moves) {
-    if (m.from() == from && m.to() == to && m.promotion() == promotion) {
-      m_position.doMove(m);
-      break;  // execute once
-    }
+    if (m.from() != from || m.to() != to) continue;
+    const core::PieceType mpromo = m.promotion();
+    if (mpromo != promotion && !(mpromo == core::PieceType::None && promotion == core::PieceType::None))
+      continue;
+    if (m_position.doMove(m)) return true;
+    return false;
   }
+  return false;
 }
 
 bool ChessGame::isKingInCheck(core::Color from) const {

--- a/src/lilia/uci/uci.cpp
+++ b/src/lilia/uci/uci.cpp
@@ -252,9 +252,7 @@ int UCI::run() {
         std::istringstream iss(movesStr);
         std::string moveUci;
         while (iss >> moveUci) {
-          try {
-            m_game.doMoveUCI(moveUci);
-          } catch (...) {
+          if (!m_game.doMoveUCI(moveUci)) {
             std::cerr << "[UCI] warning: applyMoveUCI failed for " << moveUci << "\n";
           }
         }


### PR DESCRIPTION
## Summary
- return a success flag from ChessGame::doMove and only execute legal moves
- make doMoveUCI propagate failures and log when UCI commands contain invalid moves
- guard GameManager move application against illegal moves

## Testing
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68dd3c1c63808329a79a7b908f18b725