### PR TITLE
Fix UCI move handling to reject illegal moves

### DIFF
--- a/include/lilia/model/chess_game.hpp
+++ b/include/lilia/model/chess_game.hpp
@@ -17,7 +17,7 @@ class ChessGame {
 
   void setPosition(const std::string& fen);
   void buildHash();
-  void doMove(core::Square from, core::Square to,
+  bool doMove(core::Square from, core::Square to,
               core::PieceType promotion = core::PieceType::None);
   bool doMoveUCI(const std::string& uciMove);
 

--- a/src/lilia/controller/game_manager.cpp
+++ b/src/lilia/controller/game_manager.cpp
@@ -110,7 +110,9 @@ void GameManager::completePendingPromotion(core::PieceType promotion) {
 
 void GameManager::applyMoveAndNotify(const model::Move &mv, bool onClick) {
   const core::Color mover = m_game.getGameState().sideToMove;
-  m_game.doMove(mv.from(), mv.to(), mv.promotion());
+  if (!m_game.doMove(mv.from(), mv.to(), mv.promotion())) {
+    return;
+  }
 
   bool wasPlayerMove = isHuman(mover);
 

--- a/src/lilia/model/chess_game.cpp
+++ b/src/lilia/model/chess_game.cpp
@@ -81,8 +81,7 @@ bool ChessGame::doMoveUCI(const std::string& uciMove) {
         break;
     }
   }
-  doMove(static_cast<core::Square>(from), static_cast<core::Square>(to), promo);
-  return true;
+  return doMove(static_cast<core::Square>(from), static_cast<core::Square>(to), promo);
 }
 
 std::optional<Move> ChessGame::getMove(core::Square from, core::Square to) {
@@ -288,14 +287,17 @@ bb::Piece ChessGame::getPiece(core::Square sq) {
   return opt.value_or(bb::Piece{core::PieceType::None, core::Color::White});
 }
 
-void ChessGame::doMove(core::Square from, core::Square to, core::PieceType promotion) {
+bool ChessGame::doMove(core::Square from, core::Square to, core::PieceType promotion) {
   const auto& moves = generateLegalMoves();
   for (const auto& m : moves) {
     if (m.from() == from && m.to() == to && m.promotion() == promotion) {
-      m_position.doMove(m);
+      if (m_position.doMove(m)) {
+        return true;
+      }
       break;  // execute once
     }
   }
+  return false;
 }
 
 bool ChessGame::isKingInCheck(core::Color from) const {

--- a/tests/tactical_quiet_test.cpp
+++ b/tests/tactical_quiet_test.cpp
@@ -37,6 +37,24 @@ int main() {
     assert(*res.bestMove == expected);
   }
 
+  // UCI move parsing should stay compatible with Stockfish output
+  {
+    model::ChessGame game;
+    game.setPosition(core::START_FEN);
+    assert(game.doMoveUCI("e2e4"));
+    assert(game.doMoveUCI("e7e5"));
+    assert(game.doMoveUCI("g1f3"));
+    assert(game.doMoveUCI("b8c6"));
+
+    const std::string fen = game.getFen();
+    const auto boardEnd = fen.find(' ');
+    const std::string board = fen.substr(0, boardEnd);
+    assert(board == "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R");
+
+    // Trying to play the same pawn move again must fail.
+    assert(!game.doMoveUCI("e2e4"));
+  }
+
   // Quiet piece move threatening a rook
   {
     model::ChessGame game;


### PR DESCRIPTION
## Summary
- make ChessGame::doMove report success and propagate it through doMoveUCI
- guard GUI move application against failed moves
- add a regression test that applies a Stockfish move sequence and rejects an illegal replay

## Testing
- cmake --build build
- ./build/engine_tests

------
https://chatgpt.com/codex/tasks/task_e_68dd3c1c63808329a79a7b908f18b725