### PR TITLE
Avoid copying position when filtering root moves

### DIFF
--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -1751,8 +1751,11 @@ int Search::search_root_single(model::Position& pos, int maxDepth,
       std::vector<model::Move> legalRoot;
       legalRoot.reserve(rootMoves.size());
       for (const auto& m : rootMoves) {
-        model::Position tmp = pos;
-        if (tmp.doMove(m)) legalRoot.push_back(m);
+        MoveUndoGuard guard(pos);
+        if (guard.doMove(m)) {
+          legalRoot.push_back(m);
+          guard.rollback();
+        }
       }
       rootMoves.swap(legalRoot);
     }


### PR DESCRIPTION
## Summary
- reuse the existing MoveUndoGuard to test root move legality without copying the position
- keep the root position intact by rolling the guard back explicitly after each successful move

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68e15ca1e6ac8329b6a86769e9eb4c4a