### PR TITLE
Improve SEE handling for quiet sacrifices

### DIFF
--- a/src/lilia/engine/search.cpp
+++ b/src/lilia/engine/search.cpp
@@ -1296,6 +1296,7 @@ int Search::negamax(model::Position& pos, int depth, int alpha, int beta, int pl
     // --- Always detect true checks for quiet moves (even if threat signals are gated) ---
     int pawn_sig = 0, piece_sig = 0;
     bool wouldCheck = false;
+    bool quietSacrifice = false;
     if (isQuiet) {
       const auto signals = compute_quiet_signals(pos, m);
       piece_sig = signals.pieceSignal;  // detects direct checks (==2)
@@ -1314,11 +1315,25 @@ int Search::negamax(model::Position& pos, int depth, int alpha, int beta, int pl
           pawn_sig = std::max(pawn_sig, 2);
         }
       }
+
+      if (!wouldCheck) {
+        quietSacrifice = !pos.see(m);
+        if (quietSacrifice) {
+          const auto them = core::Color(~us);
+          const auto toBB = lilia::model::bb::sq_bb(m.to());
+          lilia::model::bb::Bitboard pawnAttackers =
+              (them == core::Color::White)
+                  ? (lilia::model::bb::sw(toBB) | lilia::model::bb::se(toBB))
+                  : (lilia::model::bb::nw(toBB) | lilia::model::bb::ne(toBB));
+          pawnAttackers &= board.getPieces(them, core::PieceType::Pawn);
+          if (!pawnAttackers) quietSacrifice = false;
+        }
+      }
     }
     if (passed_push) pawn_sig = std::max(pawn_sig, 1);
     const int qp_sig = pawn_sig;
     const int qpc_sig = piece_sig;
-    const bool tacticalQuiet = (qp_sig > 0) || (qpc_sig > 0);
+    const bool tacticalQuiet = (qp_sig > 0) || (qpc_sig > 0) || quietSacrifice;
 
     // pre info
     auto moverOpt = board.getPiece(m.from());

--- a/src/lilia/model/position.cpp
+++ b/src/lilia/model/position.cpp
@@ -243,9 +243,6 @@ bool Position::see(const model::Move& m) const {
   using core::PieceType;
   using core::Square;
 
-  // Trivial non-captures: SEE is used for captures; be permissive for quiets.
-  if (!m.isCapture() && !m.isEnPassant()) return true;
-
   const auto fromP = m_board.getPiece(m.from());
   if (!fromP) return true;
 
@@ -429,6 +426,13 @@ bool Position::see(const model::Move& m) const {
     side = Color(~side);
 
     if (d >= 31) break;  // sanity guard
+  }
+
+  if (!m.isCapture() && !m.isEnPassant()) {
+    if (d == 0) return true;
+    const int lastGain = gain[d - 1];
+    const int net = (d & 1) ? lastGain : -lastGain;
+    return net >= 0;
   }
 
   // Negamax backpropagation

--- a/tests/tactical_quiet_test.cpp
+++ b/tests/tactical_quiet_test.cpp
@@ -190,6 +190,16 @@ int main() {
     }
   }
 
+  // Regression: quiet sacrifice should be explored (Stockfish-style Bc5)
+  {
+    model::ChessGame game;
+    game.setPosition("3k1b1r/Q5pp/1r2p3/8/1n1Pq3/8/PP1B1KPP/R4B1R b - - 4 23");
+    auto res = bot.findBestMove(game, 5, 0);
+    assert(res.bestMove);
+    model::Move expected(sq('f', 8), sq('c', 5));
+    assert(*res.bestMove == expected);
+  }
+
   // Regression: avoid mate blunder in tactical FEN (should play Na5b3)
   {
     model::ChessGame game;


### PR DESCRIPTION
## Summary
- update SEE to compute the net result for quiet moves instead of always succeeding
- treat pawn-attacked quiet sacrifices as tactical to avoid pruning them away in the main search
- add a regression test covering the provided quiet bishop sacrifice

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68e18479c8ac8329a5f3d729286a47c2